### PR TITLE
add moments to plot methods

### DIFF
--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -86,6 +86,7 @@ class Distribution:
 
     def plot_pdf(
         self,
+        moments=None,
         pointinterval=False,
         quantiles=None,
         support="full",
@@ -98,6 +99,10 @@ class Distribution:
 
         Parameters
         ----------
+        moments : str
+            Compute moments. Use any combination of the strings ``m``, ``d``, ``v``, ``s`` or ``k``
+            for the mean (μ), standard deviation (σ), variance (σ²), skew (γ) or kurtosis (κ)
+            respectively. Other strings will be ignored. Defaults to None.
         pointinterval : bool
             Whether to include a plot of the mean as a dot and two inter-quantile ranges as
             lines. Defaults to False.
@@ -115,19 +120,25 @@ class Distribution:
         ax : matplotlib axes
         """
         if self.is_frozen:
-            return plot_pdfpmf(self, pointinterval, quantiles, support, legend, figsize, ax)
+            return plot_pdfpmf(
+                self, moments, pointinterval, quantiles, support, legend, figsize, ax
+            )
         else:
             raise ValueError(
                 "Undefined distribution, "
                 "you need to first define its parameters or use one of the fit methods"
             )
 
-    def plot_cdf(self, support="full", legend="legend", figsize=None, ax=None):
+    def plot_cdf(self, moments=None, support="full", legend="legend", figsize=None, ax=None):
         """
         Plot the cumulative distribution function.
 
         Parameters
         ----------
+        moments : str
+            Compute moments. Use any combination of the strings ``m``, ``d``, ``v``, ``s`` or ``k``
+            for the mean (μ), standard deviation (σ), variance (σ²), skew (γ) or kurtosis (κ)
+            respectively. Other strings will be ignored. Defaults to None.
         support : str:
             If ``full`` use the finite end-points to set the limits of the plot. For unbounded
             end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
@@ -139,19 +150,23 @@ class Distribution:
         ax : matplotlib axes
         """
         if self.is_frozen:
-            return plot_cdf(self, support, legend, figsize, ax)
+            return plot_cdf(self, moments, support, legend, figsize, ax)
         else:
             raise ValueError(
                 "Undefined distribution, "
                 "you need to first define its parameters or use one of the fit methods"
             )
 
-    def plot_ppf(self, legend="legend", figsize=None, ax=None):
+    def plot_ppf(self, moments=None, legend="legend", figsize=None, ax=None):
         """
         Plot the quantile function.
 
         Parameters
         ----------
+        moments : str
+            Compute moments. Use any combination of the strings ``m``, ``d``, ``v``, ``s`` or ``k``
+            for the mean (μ), standard deviation (σ), variance (σ²), skew (γ) or kurtosis (κ)
+            respectively. Other strings will be ignored. Defaults to None.
         legend : str
             Whether to include a string with the distribution and its parameter as a ``"legend"`` a
             ``"title"`` or not include them ``None``.
@@ -160,7 +175,7 @@ class Distribution:
         ax : matplotlib axes
         """
         if self.is_frozen:
-            return plot_ppf(self, legend, figsize, ax)
+            return plot_ppf(self, moments, legend, figsize, ax)
         else:
             raise ValueError(
                 "Undefined distribution, "

--- a/preliz/utils/plot_utils.py
+++ b/preliz/utils/plot_utils.py
@@ -23,10 +23,12 @@ def plot_pointinterval(distribution, quantiles, ax):
     ax.plot(median, 0, "w.")
 
 
-def plot_pdfpmf(dist, pointinterval, quantiles, support, legend, figsize, ax):
+def plot_pdfpmf(dist, moments, pointinterval, quantiles, support, legend, figsize, ax):
     ax = get_ax(ax, figsize)
     color = next(ax._get_lines.prop_cycler)["color"]
     label = repr_to_matplotlib(dist)
+    if moments is not None:
+        label += get_moments(dist, moments)
 
     x = dist.xvals(support)
     if dist.kind == "continuous":
@@ -46,10 +48,12 @@ def plot_pdfpmf(dist, pointinterval, quantiles, support, legend, figsize, ax):
     return ax
 
 
-def plot_cdf(dist, support, legend, figsize, ax):
+def plot_cdf(dist, moments, support, legend, figsize, ax):
     ax = get_ax(ax, figsize)
     color = next(ax._get_lines.prop_cycler)["color"]
     label = repr_to_matplotlib(dist)
+    if moments is not None:
+        label += get_moments(dist, moments)
 
     eps = dist.finite_endpoints(support)
     x = np.linspace(*eps, 1000)
@@ -63,10 +67,12 @@ def plot_cdf(dist, support, legend, figsize, ax):
     return ax
 
 
-def plot_ppf(dist, legend, figsize, ax):
+def plot_ppf(dist, moments, legend, figsize, ax):
     ax = get_ax(ax, figsize)
     color = next(ax._get_lines.prop_cycler)["color"]
     label = repr_to_matplotlib(dist)
+    if moments is not None:
+        label += get_moments(dist, moments)
 
     x = np.linspace(0, 1, 1000)
     ax.plot(x, dist.rv_frozen.ppf(x), label=label, color=color)
@@ -99,3 +105,27 @@ def repr_to_matplotlib(distribution):
     string = string.replace("\x1b[1m", r"$\bf{")
     string = string.replace("\x1b[0m", "}$")
     return string
+
+
+def get_moments(dist, moments):
+    names = {
+        "m": "μ",
+        "d": "σ",
+        "s": "γ",
+        "v": "σ²",
+        "k": "κ",
+    }
+    str_m = []
+    seen = []
+    for moment in moments:
+        if moment not in seen:
+            if moment == "d":
+                value = dist.rv_frozen.stats("v") ** 0.5
+            else:
+                value = dist.rv_frozen.stats(moment)
+            if isinstance(value, (np.ndarray, int, float)):
+                str_m.append(f"{names[moment]}={value:.3g}")
+
+        seen.append(moment)
+
+    return "\n" + ", ".join(str_m)


### PR DESCRIPTION
This adds the `moments` argument to `dist.plot_*()`. As in SciPy, the requested moments are specified with the strings "m", "v", "s" "k". Additionally, we support "d" for the standard deviation. Other strings are ignored, as well as duplicated strings. Order is preserved in the legend/title.