### PR TITLE
add custom support

### DIFF
--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -608,7 +608,8 @@ class Uniform(Continuous):
         ls = [1, -2]
         us = [6, 2]
         for l, u in zip(ls, us):
-            Uniform(l, u).plot_pdf()
+            ax = Uniform(l, u).plot_pdf()
+        ax.set_ylim(0, 0.3)
 
     ========  =====================================
     Support   :math:`x \in [lower, upper]`

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -107,7 +107,7 @@ class DiscreteUniform(Discrete):
         ls = [1, -2]
         us = [6, 2]
         for l, u in zip(ls, us):
-            DiscreteUniform(l, u).plot_pdf()
+            DiscreteUniform(l, u).plot_pdf(support=(-3, 7))
 
     ========  ===============================================
     Support   :math:`x \in {lower, lower + 1, \ldots, upper}`

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -72,16 +72,19 @@ class Distribution:
 
         Parameters
         ----------
-        support : str
-            Available options are "full" or "restricted".
+        support : str or tuple
+            Available string options are "full" or "restricted".
         """
-        lower_ep = self.rv_frozen.a
-        upper_ep = self.rv_frozen.b
+        if isinstance(support, tuple):
+            lower_ep, upper_ep = support
+        else:
+            lower_ep = self.rv_frozen.a
+            upper_ep = self.rv_frozen.b
 
-        if not np.isfinite(lower_ep) or support == "restricted":
-            lower_ep = self.rv_frozen.ppf(0.0001)
-        if not np.isfinite(upper_ep) or support == "restricted":
-            upper_ep = self.rv_frozen.ppf(0.9999)
+            if not np.isfinite(lower_ep) or support == "restricted":
+                lower_ep = self.rv_frozen.ppf(0.0001)
+            if not np.isfinite(upper_ep) or support == "restricted":
+                upper_ep = self.rv_frozen.ppf(0.9999)
 
         return lower_ep, upper_ep
 

--- a/preliz/utils/plot_utils.py
+++ b/preliz/utils/plot_utils.py
@@ -36,8 +36,13 @@ def plot_pdfpmf(dist, moments, pointinterval, quantiles, support, legend, figsiz
         ax.plot(x, density, label=label, color=color)
         ax.set_yticks([])
     else:
-        density = dist.rv_frozen.pmf(x)
-        ax.plot(x, density, "-o", label=label, color=color)
+        mass = dist.rv_frozen.pmf(x)
+        eps = dist.finite_endpoints(support)
+        x_c = np.linspace(*eps, 1000)
+        mass_c = np.clip(dist.rv_frozen.pmf(x_c), 0, np.max(mass))
+        ax.plot(x_c, mass_c, ls="dotted", color=color)
+        ax.plot(x, mass, "o", label=label, color=color)
+
     if pointinterval:
         plot_pointinterval(dist.rv_frozen, quantiles, ax)
 


### PR DESCRIPTION
Also make discrete pmf plots a little bit nicer, by having a dotted smooth auxiliary curve.

with custom support
![output](https://user-images.githubusercontent.com/1338958/178528570-e11c22ba-1fc8-49bf-a5dc-98af6227a7f8.png)

with full support
![output](https://user-images.githubusercontent.com/1338958/178528805-35ede5a2-0f81-481e-b528-0a58fa84ec35.png)
