### PR TITLE
Prior predictive check assistant

### DIFF
--- a/preliz/ppa.py
+++ b/preliz/ppa.py
@@ -120,7 +120,8 @@ def more(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, k
         plt.setp(ax.spines.values(), color="k", lw=1)
     for ax in axes:
         ax.cla()
-    clicked = []
+    for ax in list(clicked):
+        clicked.remove(ax)
 
     pp_samples_idxs, shown = keep_sampling(pp_summary, choices, shown, kdt)
     fig, _ = plot_samples(pp_samples, pp_samples_idxs, fig)

--- a/preliz/ppa.py
+++ b/preliz/ppa.py
@@ -3,10 +3,10 @@
 import logging
 
 import arviz as az
+import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial import KDTree
-import ipywidgets as widgets
 
 
 from preliz import distributions
@@ -30,9 +30,9 @@ def ppa(idata, model, summary="octiles"):
     ----------
 
     idata : InferenceData
-        With samples from the prior and prior predictive distributions
+        With at least the `prior` and `prior_predictive` groups
     model : PyMC model
-        Model associated to ``ìdata``.
+        Model associated to ``idata``.
     summary : str:
         Summary statistics applied to prior samples in order to define (dis)similarity
         of distributions. Current options are `octiles`, `hexiles`, `quantiles`,
@@ -58,32 +58,31 @@ def ppa(idata, model, summary="octiles"):
     pp_samples = idata.prior_predictive[obs_rv].squeeze().values
     prior_samples = idata.prior.squeeze()
     sample_size = pp_samples.shape[0]
-    pp_summary, kdt = pre_processing(pp_samples, summary)
+    pp_summary, kdt = compute_summaries(pp_samples, summary)
     pp_samples_idxs, shown = initialize_subsamples(pp_summary, shown, kdt)
     fig, axes = plot_samples(pp_samples, pp_samples_idxs)
 
     clicked = []
     selected = []
     choices = []
-    subsample = []
 
     output = widgets.Output()
 
     with output:
-        button_keep = widgets.Button(description="continue")
-        button_ready = widgets.Button(description="return prior")
+        button_carry_on = widgets.Button(description="carry on")
+        button_return_prior = widgets.Button(description="return prior")
 
-        def more_(_):
-            more(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, kdt)
+        def carry_on_(_):
+            carry_on(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, kdt)
 
-        button_keep.on_click(more_)
+        button_carry_on.on_click(carry_on_)
 
-        def on_ready_(_):
-            on_ready(fig, selected, model, sample_size, subsample)
+        def on_return_prior_(_):
+            on_return_prior(fig, selected, model, sample_size)
 
-        button_ready.on_click(on_ready_)
+        button_return_prior.on_click(on_return_prior_)
 
-        def pick(event):
+        def click(event):
             if event.inaxes not in clicked:
                 clicked.append(event.inaxes)
             else:
@@ -94,28 +93,41 @@ def ppa(idata, model, summary="octiles"):
                 plt.setp(ax.spines.values(), color="C1", lw=3)
             fig.canvas.draw()
 
-        def on_ready(fig, selected, model, sample_size, subsample):
+        def on_return_prior(fig, selected, model, sample_size):
             selected = np.unique(selected)
-            subsample = resample(selected, prior_samples, model)
-            string = back_fitting(model, subsample, sample_size)
+            num_selected = len(selected)
 
-            fig.clf()
-            plt.text(0.2, 0.5, string, fontsize=14)
-            plt.yticks([])
-            plt.xticks([])
+            if num_selected > 1:
+                string = (
+                    f"You have selected {num_selected} out of {sample_size} prior"
+                    "predictive samples\nThat selection is consistent with the"
+                    "following priors:\n"
+                )
+
+                subsample = select_prior_samples(selected, prior_samples, model)
+                string = back_fitting(model, subsample, string)
+
+                fig.clf()
+                plt.text(0.2, 0.5, string, fontsize=14)
+                plt.yticks([])
+                plt.xticks([])
+            else:
+                fig.suptitle("Please select more distributions", fontsize=16)
+
             fig.canvas.draw()
 
-        fig.canvas.mpl_connect("button_press_event", pick)
+        fig.canvas.mpl_connect("button_press_event", click)
 
-    controls = widgets.VBox([button_keep, button_ready])
+    controls = widgets.VBox([button_carry_on, button_return_prior])
 
     display(widgets.HBox([controls]))  # pylint:disable=undefined-variable
 
 
-def more(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, kdt):
+def carry_on(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, kdt):
     choices.extend([int(ax.get_title()) for ax in clicked])
     selected.extend(choices)
 
+    fig.suptitle("")
     for ax in clicked:
         plt.setp(ax.spines.values(), color="k", lw=1)
     for ax in axes:
@@ -124,11 +136,13 @@ def more(fig, axes, clicked, pp_samples, pp_summary, choices, selected, shown, k
         clicked.remove(ax)
 
     pp_samples_idxs, shown = keep_sampling(pp_summary, choices, shown, kdt)
+    if not pp_samples_idxs:
+        pp_samples_idxs, shown = initialize_subsamples(pp_summary, shown, kdt)
     fig, _ = plot_samples(pp_samples, pp_samples_idxs, fig)
     fig.canvas.draw()
 
 
-def pre_processing(pp_samples, summary):
+def compute_summaries(pp_samples, summary):
     if summary == "octiles":
         pp_summary = np.quantile(
             pp_samples, [0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875], axis=1
@@ -178,7 +192,10 @@ def initialize_subsamples(pp_summary, shown, kdt):
 
 
 def keep_sampling(pp_summary, choices, shown, kdt):
-    # Select distributions that are similar
+    """
+    Find distribution similar to the ones in `choices`, but not already shown.
+    If `choices` is empty return an empty selection.
+    """
     if choices:
         new = choices.pop(0)
         samples = [new]
@@ -224,39 +241,30 @@ def plot_samples(pp_samples, pp_samples_idxs, fig=None):
     return fig, axes
 
 
-def resample(selected, prior_samples, model):
-    ## Change name of the function
+def select_prior_samples(selected, prior_samples, model):
+    """
+    Given a selected set of prior predictive samples pick the corresponding
+    prior samples.
+    """
     rvs = model.unobserved_RVs  # we should exclude deterministics
     rv_names = [rv.name for rv in rvs]
     subsample = {rv: prior_samples[rv].sel(draw=selected).values.squeeze() for rv in rv_names}
 
-    # # posti = pm.sample_posterior_predictive(az.from_dict(dado), model=model)
-    # # dado.update(posti)
     return subsample
 
 
-def back_fitting(model, pps1, sample_size):
-    subset = len(pps1[list(pps1.keys())[0]])
-
-    string = f"You have selected {subset} out of {sample_size} prior predictive samples\n"
-    string += "That selection is consistent with the following priors:\n"
-
+def back_fitting(model, subset, string):
+    """
+    Use MLE to fit a subset of the prior samples to the individual prior distributions
+    """
     for unobserved in model.unobserved_RVs:
         distribution = unobserved.owner.op.name
         dist = getattr(distributions, pymc_to_preliz[distribution])()
-        # pymc_name, sp_rv = pymc_to_scipy[distribution]
         name = unobserved.name
         idx = unobserved.owner.nin - 3
         params = unobserved.owner.inputs[-idx:]
         is_fitable = any(param.name is None for param in params)
         if is_fitable:
-            # pymc_name, sp_rv = pymc_to_scipy[distribution]
-            dist._fit_mle(pps1[name])
+            dist._fit_mle(subset[name])
             string += f"{repr_to_matplotlib(dist)}\n"
-            # string += f'{name} = pm.{pymc_name}("{name}", '
-            # if distribution == "normal":
-            #    string += f"{prior[0]:.2f}, {prior[1]:.2f})\n"
-            # elif distribution == "halfnormal":
-            #    string += f"{prior[1]:.2f})\n"
-
     return string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
   "matplotlib>=3.5",
   "nbclient<0.6,>=0.2",
   "ipywidgets",
-  "scikit-learn",
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
This is the first version of a "prior predictive check assistant" (actually the second, there was a previous attempt using a slightly different approach).  This is not a very smart assistant, so we could pick a different name, or work to make it more intelligent :-) or maybe both! 

Anyway, the main goal of this function is to help refine priors. The assumption is that we often choose priors that are wider than our actual prior information (like the slope being a priori on the real line, when we know positive values are actually disallowed by theory or experience), so with a little bit of help, we can refine priors.

Inspecting the prior predictive distribution can help us check if priors/models are in agreement with previous knowledge. This is just one function to help with that inspection. Not the only possible tool, actually we should have more functions/tools in PreliZ based on prior predictive distributions. 

So what this function does:

1) It needs a sample from the prior and from the prior predictive.
2) At the beginning it shows 9 draws from the prior predictive at random. The first one is chosen at random and the rest as further neighbours from the previous one. Duplications are not allowed. Each distribution is represented using a KDEs, with a pointinterval. In the future users should be able to switch, at any point, between more options, histograms, ECDFs, quantile, dotplots, etc
3) Then the user is asked to pick one or more draws and press a button once the selection is ready.
4) From each selected draw the function will find 9 nearest neighbours and show them to the user. If the nearest neighbours have already been returned, the search will continue with further and further neighbours. 
5) The selection process is repeated until the user wants (or there are no more distributions to show). If at any instance there are no more nearest neighbours to show, the function will do the same as it was done at initialization (pick a new draw at random, choose the others by further neighbours). 
6) When the user is ready it can ask for a prior
7) Internally the function will select the subset of priors draws corresponding to the user selected prior predictive draws and it will do a maximum likelihood fit of those samples to the prior distribution in the model.


This current code runs and it is mostly usable, but bugs are very likely to be there. A few things that will need to be done in future PRs

1) Allow representations other that the KDE
2) Allow non-random initialization. A few options, 2 to 4 first moments, a fitted preliz distribution (from maxent, roulette or whatever), or a hand-drawn distribution. Limits, (upper or lower, or both) or x% mass between limits, etc...
3) This definitely needs more tests  (both for CI and using it/simulating being and user ) and probably refine and refactor internals
4) Expand to more models, the logic for back_fitting the prior draws to the prior was done quickly and needs improvements.
 

