### PR TITLE
Add alternative parametrization for beta distribution

### DIFF
--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -45,9 +45,10 @@ class Beta(Continuous):
     Variance  :math:`\dfrac{\alpha \beta}{(\alpha+\beta)^2(\alpha+\beta+1)}`
     ========  ==============================================================
 
-    Beta distribution can be parameterized either in terms of alpha and
-    beta or mean and standard deviation. The link between the two
-    parametrizations is given by
+    Beta distribution has 3 alternative parameterizations. In terms of alpha and
+    beta, mean and sigma (standard deviation) or mean and kappa (concentration).
+
+    The link between the 3 alternatives is given by
 
     .. math::
 
@@ -55,6 +56,7 @@ class Beta(Continuous):
        \beta  &= (1 - \mu) \kappa
 
        \text{where } \kappa = \frac{\mu(1-\mu)}{\sigma^2} - 1
+
 
     Parameters
     ----------
@@ -66,6 +68,8 @@ class Beta(Continuous):
         mean (0 < ``mu`` < 1).
     sigma : float
         standard deviation (``sigma`` < sqrt(``mu`` * (1 - ``mu``))).
+    kappa : float
+        concentration > 0
     """
 
     def __init__(self, alpha=None, beta=None, mu=None, sigma=None, kappa=None):

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -25,8 +25,15 @@ class Distribution:
     def __repr__(self):
         if self.is_frozen:
             bolded_name = "\033[1m" + self.name.capitalize() + "\033[0m"
+
+            # temporary patch until we migrate all distributions to use
+            # self.params_report and self.params
+            try:
+                params_value = self.params_report
+            except AttributeError:
+                params_value = self.params
             description = "".join(
-                f"{n}={v:.2f}," for n, v in zip(self.param_names, self.params)
+                f"{n}={v:.2f}," for n, v in zip(self.param_names, params_value)
             ).strip(",")
             return f"{bolded_name}({description})"
         else:

--- a/preliz/tests/test_distributions.py
+++ b/preliz/tests/test_distributions.py
@@ -127,3 +127,19 @@ def test_summary(fmt, mass):
     assert result._fields == ("mean", "median", "std", "lower", "upper")
     result = Poisson(2).summary()
     assert result.mean == 2
+
+
+@pytest.mark.parametrize(
+    "distribution, params, alt_names",
+    [
+        (Beta, (2, 5), ("mu", "sigma")),
+        (Beta, (5, 2), ("mu", "kappa")),
+    ],
+)
+def test_alternative_parametrization(distribution, params, alt_names):
+    dist0 = distribution(*params)
+    params1 = {p: getattr(dist0, p) for p in alt_names}
+    dist1 = distribution(**params1)
+    assert_almost_equal(dist0.params, dist1.params)
+    for p in alt_names:
+        assert p in dist1.__repr__()


### PR DESCRIPTION
Extends the Beta distribution to be parametrized in terms of mu and sigma (standard deviation) or mu and kappa (concentration).

This also works as a reference for future alternative parametrization of other distributions. The approach is to use one parametrization for all internals and just have a few functions to convert from that parametrization to the others. The conversion is to keep all parameters values updated (even those not directly set by the user) and to report (plots and string repr) the parameters using the user's choice.