### PR TITLE
fix corner case for ylim

### DIFF
--- a/preliz/utils/plot_utils.py
+++ b/preliz/utils/plot_utils.py
@@ -59,6 +59,7 @@ def plot_pdfpmf(dist, moments, pointinterval, quantiles, support, legend, figsiz
     if dist.kind == "continuous":
         density = dist.rv_frozen.pdf(x)
         ax.plot(x, density, label=label, color=color)
+        ax.get_ylim()
         ax.set_yticks([])
     else:
         mass = dist.rv_frozen.pmf(x)


### PR DESCRIPTION
Automatic ylim setting was not giving a good looking plot for some cases like beta(1, 1)