### PR TITLE
add interactive method to distributions

### DIFF
--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -329,7 +329,7 @@ class Distribution:
                 "you need to first define its parameters or use one of the fit methods"
             )
 
-    def interactive(self, kind="pdf", xlim=None, fixed_lim="both"):
+    def interactive(self, kind="pdf", fixed_lim="both", pointinterval=True, quantiles=None):
         """
         Interactive exploration of distributions parameters
 
@@ -343,6 +343,13 @@ class Distribution:
             Use `"auto"` for automatic rescaling of x-axis and y-axis.
             Or set them manually by passing a tuple of 4 elements,
             the first two fox x-axis, the last two for x-axis. The tuple can have `None`.
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        quantiles : list
+            Values of the five quantiles to use when ``pointinterval=True`` if None (default)
+            the values ``[0.05, 0.25, 0.5, 0.75, 0.95]`` will be used. The number of elements
+            should be 5, 3, 1 or 0 (in this last case nothing will be plotted).
         """
 
         # temporary patch until we migrate all distributions to use
@@ -377,16 +384,22 @@ class Distribution:
 
             step = (max_v - min_v) / 100
 
-            sliders[name] = ipyw.FloatSlider(min=min_v, max=max_v, step=step, value=value)
+            sliders[name] = ipyw.FloatSlider(
+                min=min_v,
+                max=max_v,
+                step=step,
+                description=f"{name} ({lower:.0f}, {upper:.0f})",
+                value=value,
+            )
 
         def plot(**args):
             self.__init__(**args)
             if kind == "pdf":
-                ax = self.plot_pdf(legend=False)
+                ax = self.plot_pdf(legend=False, pointinterval=pointinterval, quantiles=quantiles)
             elif kind == "cdf":
-                ax = self.plot_cdf(legend=False)
+                ax = self.plot_cdf(legend=False, pointinterval=pointinterval, quantiles=quantiles)
             elif kind == "ppf":
-                ax = self.plot_ppf(legend=False)
+                ax = self.plot_ppf(legend=False, pointinterval=pointinterval, quantiles=quantiles)
             if fixed_lim != "auto" and kind != "ppf":
                 ax.set_xlim(*xlim)
             if fixed_lim != "auto" and kind != "cdf":

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -329,7 +329,7 @@ class Distribution:
                 "you need to first define its parameters or use one of the fit methods"
             )
 
-    def interactive(self, kind="pdf", xlim=None, fixed_lim=None):
+    def interactive(self, kind="pdf", xlim=None, fixed_lim="both"):
         """
         Interactive exploration of distributions parameters
 
@@ -337,12 +337,12 @@ class Distribution:
         ----------
         kind : str:
             Type of plot. Available options are `pdf`, `cdf` and `ppf`.
-        fixed_lim : tuple or str
-            Values to set the limits of the x-axis and y-axis.
-            Defaults to None, the values are computed automatically.
-            Use `both` for automatic rescaling of x-axis and y-axis. Or pass a tuple
-            of 4 elements the first two fox x-axis, the last two for x-axis. The elements
-            of the tuple can be `None`.
+        fixed_lim : str or tuple
+            Set the limits of the x-axis and/or y-axis.
+            Defaults to `"both"`, the limits of both axis are fixed.
+            Use `"auto"` for automatic rescaling of x-axis and y-axis.
+            Or set them manually by passing a tuple of 4 elements,
+            the first two fox x-axis, the last two for x-axis. The tuple can have `None`.
         """
 
         # temporary patch until we migrate all distributions to use
@@ -354,12 +354,12 @@ class Distribution:
 
         args = dict(zip(self.param_names, params_value))
 
-        if fixed_lim is None:
+        if fixed_lim == "both":
             self.__init__(**args)
             xlim = self._finite_endpoints("full")
             xvals = self.xvals("restricted")
             ylim = (0, np.max(self.pdf(xvals) * 1.5))
-        if isinstance(fixed_lim, tuple):
+        elif isinstance(fixed_lim, tuple):
             xlim = fixed_lim[:2]
             ylim = fixed_lim[2:]
 
@@ -387,9 +387,9 @@ class Distribution:
                 ax = self.plot_cdf(legend=False)
             elif kind == "ppf":
                 ax = self.plot_ppf(legend=False)
-            if fixed_lim != "both" and kind != "ppf":
+            if fixed_lim != "auto" and kind != "ppf":
                 ax.set_xlim(*xlim)
-            if fixed_lim != "both" and kind != "cdf":
+            if fixed_lim != "auto" and kind != "cdf":
                 ax.set_ylim(*ylim)
 
         interact(plot, **sliders)


### PR DESCRIPTION
closes #144. This allows setting the parameters of distribution interactively using sliders.

![Captura desde 2022-12-16 20-34-18](https://user-images.githubusercontent.com/1338958/208207921-a24d09ad-a4b4-489f-ae8c-9e27eebaaab1.png)


There are still some issues, but I left those for future PRs. For example, the user needs to define starting values, but it could be useful to offer some arbitrary values by default, especially for newbie users and/or not very common distributions. There is also a dirty heuristic to define the min, max, and step values of sliders, which could be better, etc.
