### PR TITLE
refactor plot_interactive, enforce correct parameter types

### DIFF
--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -124,9 +124,9 @@ class AsymmetricLaplace(Continuous):
         return frozen
 
     def _update(self, kappa, mu, b):
-        self.kappa = kappa
-        self.mu = mu
-        self.b = b
+        self.kappa = float(kappa)
+        self.mu = float(mu)
+        self.b = float(b)
         self.q = self._to_q(self.kappa)
 
         if self.param_names[0] == "kappa":
@@ -267,8 +267,8 @@ class Beta(Continuous):
         return frozen
 
     def _update(self, alpha, beta):
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.mu, self.sigma = self._to_mu_sigma(self.alpha, self.beta)
         self.kappa = self.mu * (1 - self.mu) / self.sigma**2 - 1
 
@@ -360,12 +360,12 @@ class BetaScaled(Continuous):
 
     def _update(self, alpha, beta, lower=None, upper=None):
         if lower is not None:
-            self.lower = lower
+            self.lower = float(lower)
         if upper is not None:
-            self.upper = upper
+            self.upper = float(upper)
 
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.params = (self.alpha, self.beta, self.lower, self.upper)
         self.support = self.lower, self.upper
         self._update_rv_frozen()
@@ -442,8 +442,8 @@ class Cauchy(Continuous):
         return frozen
 
     def _update(self, alpha, beta):
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.params = (self.alpha, self.beta)
         self._update_rv_frozen()
 
@@ -504,7 +504,8 @@ class ChiSquared(Continuous):
         self.param_names = ("nu",)
         self.params_support = ((eps, np.inf),)
         self.params = (self.nu,)
-        self._update(self.nu)
+        if self.nu is not None:
+            self._update(self.nu)
 
     def _get_frozen(self):
         frozen = None
@@ -513,7 +514,7 @@ class ChiSquared(Continuous):
         return frozen
 
     def _update(self, nu):
-        self.nu = nu
+        self.nu = float(nu)
         self.params = (self.nu,)
         self._update_rv_frozen()
 
@@ -597,9 +598,9 @@ class ExGaussian(Continuous):
         return frozen
 
     def _update(self, mu, sigma, nu):
-        self.nu = nu
-        self.mu = mu
-        self.sigma = sigma
+        self.nu = float(nu)
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.params = (self.mu, self.sigma, self.nu)
         self._update_rv_frozen()
 
@@ -657,7 +658,8 @@ class Exponential(Continuous):
         self.params = (self.lam,)
         self.param_names = ("lam",)
         self.params_support = ((eps, np.inf),)
-        self._update(self.lam)
+        if self.lam is not None:
+            self._update(self.lam)
 
     def _get_frozen(self):
         frozen = None
@@ -666,7 +668,7 @@ class Exponential(Continuous):
         return frozen
 
     def _update(self, lam):
-        self.lam = lam
+        self.lam = float(lam)
         self.params = (self.lam,)
         self._update_rv_frozen()
 
@@ -777,8 +779,8 @@ class Gamma(Continuous):
         return frozen
 
     def _update(self, alpha, beta):
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.mu, self.sigma = self._to_mu_sigma(self.alpha, self.beta)
 
         if self.param_names[0] == "alpha":
@@ -851,7 +853,8 @@ class Gumbel(Continuous):
         self.params = (self.mu, self.beta)
         self.param_names = ("mu", "beta")
         self.params_support = ((-np.inf, np.inf), (eps, np.inf))
-        self._update(self.mu, self.beta)
+        if (self.mu and self.beta) is not None:
+            self._update(self.mu, self.beta)
 
     def _get_frozen(self):
         frozen = None
@@ -860,8 +863,8 @@ class Gumbel(Continuous):
         return frozen
 
     def _update(self, mu, beta):
-        self.mu = mu
-        self.beta = beta
+        self.mu = float(mu)
+        self.beta = float(beta)
         self.params = (self.mu, self.beta)
         self._update_rv_frozen()
 
@@ -919,7 +922,8 @@ class HalfCauchy(Continuous):
         self.params = (self.beta,)
         self.param_names = ("beta",)
         self.params_support = ((eps, np.inf),)
-        self._update(self.beta)
+        if self.beta is not None:
+            self._update(self.beta)
 
     def _get_frozen(self):
         frozen = None
@@ -928,7 +932,7 @@ class HalfCauchy(Continuous):
         return frozen
 
     def _update(self, beta):
-        self.beta = beta
+        self.beta = float(beta)
         self.params = (self.beta,)
         self._update_rv_frozen()
 
@@ -1015,7 +1019,7 @@ class HalfNormal(Continuous):
         return frozen
 
     def _update(self, sigma):
-        self.sigma = sigma
+        self.sigma = float(sigma)
         self.tau = to_precision(sigma)
 
         if self.param_names[0] == "sigma":
@@ -1124,8 +1128,8 @@ class HalfStudent(Continuous):
         return frozen
 
     def _update(self, nu, sigma):
-        self.nu = nu
-        self.sigma = sigma
+        self.nu = float(nu)
+        self.sigma = float(sigma)
         self.lam = to_precision(sigma)
 
         if self.param_names[1] == "sigma":
@@ -1315,8 +1319,8 @@ class InverseGamma(Continuous):
         return frozen
 
     def _update(self, alpha, beta):
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.mu, self.sigma = self._to_mu_sigma(self.alpha, self.beta)
 
         if self.param_names[0] == "alpha":
@@ -1394,8 +1398,8 @@ class Laplace(Continuous):
         return frozen
 
     def _update(self, mu, b):
-        self.mu = mu
-        self.b = b
+        self.mu = float(mu)
+        self.b = float(b)
         self.params = (self.mu, self.b)
         self._update_rv_frozen()
 
@@ -1460,7 +1464,8 @@ class Logistic(Continuous):
         self.params = (self.mu, self.s)
         self.param_names = ("mu", "s")
         self.params_support = ((-np.inf, np.inf), (eps, np.inf))
-        self._update(self.mu, self.s)
+        if (self.mu and self.s) is not None:
+            self._update(self.mu, self.s)
 
     def _get_frozen(self):
         frozen = None
@@ -1469,8 +1474,8 @@ class Logistic(Continuous):
         return frozen
 
     def _update(self, mu, s):
-        self.mu = mu
-        self.s = s
+        self.mu = float(mu)
+        self.s = float(s)
         self.params = (self.mu, self.s)
         self._update_rv_frozen()
 
@@ -1549,8 +1554,8 @@ class LogNormal(Continuous):
         return frozen
 
     def _update(self, mu, sigma):
-        self.mu = mu
-        self.sigma = sigma
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.params = (self.mu, self.sigma)
         self._update_rv_frozen()
 
@@ -1630,8 +1635,8 @@ class Moyal(Continuous):
         return frozen
 
     def _update(self, mu, sigma):
-        self.mu = mu
-        self.sigma = sigma
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.params = (self.mu, self.sigma)
         self._update_rv_frozen()
 
@@ -1727,8 +1732,8 @@ class Normal(Continuous):
         return frozen
 
     def _update(self, mu, sigma):
-        self.mu = mu
-        self.sigma = sigma
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.tau = to_precision(sigma)
 
         if self.param_names[1] == "sigma":
@@ -1804,9 +1809,9 @@ class Pareto(Continuous):
         return frozen
 
     def _update(self, alpha, m):
-        self.alpha = alpha
-        self.m = m
-        self.support = (m, np.inf)
+        self.alpha = float(alpha)
+        self.m = float(m)
+        self.support = (self.m, np.inf)
         self.params = (self.alpha, self.m)
         self._update_rv_frozen()
 
@@ -1908,9 +1913,9 @@ class SkewNormal(Continuous):
         return frozen
 
     def _update(self, mu, sigma, alpha):
-        self.mu = mu
-        self.sigma = sigma
-        self.alpha = alpha
+        self.mu = float(mu)
+        self.sigma = float(sigma)
+        self.alpha = float(alpha)
         self.tau = to_precision(sigma)
 
         if self.param_names[1] == "sigma":
@@ -2020,9 +2025,9 @@ class Student(Continuous):
         return frozen
 
     def _update(self, nu, mu, sigma):
-        self.nu = nu
-        self.mu = mu
-        self.sigma = sigma
+        self.nu = float(nu)
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.lam = to_precision(sigma)
 
         if self.param_names[2] == "sigma":
@@ -2122,9 +2127,9 @@ class Triangular(Continuous):
         return frozen
 
     def _update(self, lower, c, upper):
-        self.lower = lower
-        self.c = c
-        self.upper = upper
+        self.lower = float(lower)
+        self.c = float(c)
+        self.upper = float(upper)
         self.support = (self.lower, self.upper)
         self.params = (self.lower, self.c, self.upper)
         self._update_rv_frozen()
@@ -2222,12 +2227,12 @@ class TruncatedNormal(Continuous):
 
     def _update(self, mu, sigma, lower=None, upper=None):
         if lower is not None:
-            self.lower = lower
+            self.lower = float(lower)
         if upper is not None:
-            self.upper = upper
+            self.upper = float(upper)
 
-        self.mu = mu
-        self.sigma = sigma
+        self.mu = float(mu)
+        self.sigma = float(sigma)
         self.params = (self.mu, self.sigma, self.lower, self.upper)
         self.support = (self.lower, self.upper)
         self._update_rv_frozen()
@@ -2308,8 +2313,8 @@ class Uniform(Continuous):
         return frozen
 
     def _update(self, lower, upper):
-        self.lower = lower
-        self.upper = upper
+        self.lower = float(lower)
+        self.upper = float(upper)
         self.params = (self.lower, self.upper)
         self.support = (self.lower, self.upper)
         self._update_rv_frozen()
@@ -2385,8 +2390,8 @@ class VonMises(Continuous):
         return frozen
 
     def _update(self, mu, kappa):
-        self.mu = mu
-        self.kappa = kappa
+        self.mu = float(mu)
+        self.kappa = float(kappa)
         self.params = (self.mu, self.kappa)
         self._update_rv_frozen()
 
@@ -2461,8 +2466,8 @@ class Wald(Continuous):
         return frozen
 
     def _update(self, mu, lam):
-        self.mu = mu
-        self.lam = lam
+        self.mu = float(mu)
+        self.lam = float(lam)
         self.params = (self.mu, self.lam)
         self._update_rv_frozen()
 
@@ -2534,8 +2539,8 @@ class Weibull(Continuous):
         return frozen
 
     def _update(self, alpha, beta):
-        self.alpha = alpha
-        self.beta = beta
+        self.alpha = float(alpha)
+        self.beta = float(beta)
         self.params = (self.alpha, self.beta)
         self._update_rv_frozen()
 

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -80,7 +80,7 @@ class Binomial(Discrete):
 
     def _update(self, n, p):
         self.n = int(n)
-        self.p = p
+        self.p = float(p)
         self.params = (self.n, self.p)
         self.support = (0, self.n)
         self._update_rv_frozen()
@@ -290,8 +290,8 @@ class NegativeBinomial(Discrete):
         return frozen
 
     def _update(self, mu, alpha):
-        self.mu = mu
-        self.alpha = alpha
+        self.mu = float(mu)
+        self.alpha = float(alpha)
         self.p, self.n = self._to_p_n(self.mu, self.alpha)
 
         if self.param_names[0] == "mu":
@@ -370,7 +370,7 @@ class Poisson(Discrete):
         return frozen
 
     def _update(self, mu):
-        self.mu = mu
+        self.mu = float(mu)
         self.params = (self.mu,)
         self._update_rv_frozen()
 

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -5,11 +5,10 @@ Parent classes for all families.
 from collections import namedtuple
 
 from ipywidgets import interact
-import ipywidgets as ipyw
 import numpy as np
 
 from ..utils.plot_utils import plot_pdfpmf, plot_cdf, plot_ppf
-from ..utils.utils import hdi_from_pdf
+from ..utils.utils import hdi_from_pdf, get_slider
 
 
 class Distribution:
@@ -359,28 +358,8 @@ class Distribution:
         sliders = {}
         for name, value, support in zip(self.param_names, self.params, self.params_support):
             lower, upper = support
-            if np.isfinite(lower):
-                min_v = lower
-            else:
-                min_v = value - 10
-            if np.isfinite(upper):
-                max_v = upper
-            else:
-                max_v = value + 10
 
-            if isinstance(value, float):
-                slider_type = ipyw.FloatSlider
-                step = (max_v - min_v) / 100
-            else:
-                slider_type = ipyw.FloatSlider
-                step = 1
-            sliders[name] = slider_type(
-                min=min_v,
-                max=max_v,
-                step=step,
-                description=f"{name} ({lower:.0f}, {upper:.0f})",
-                value=value,
-            )
+            sliders[name] = get_slider(name, value, lower, upper)
 
         def plot(**args):
             self.__init__(**args)

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -350,7 +350,8 @@ class Distribution:
             self.__init__(**args)
             xlim = self._finite_endpoints("full")
             xvals = self.xvals("restricted")
-            ylim = (0, np.max(self.pdf(xvals) * 1.5))
+            max_pdf = np.max(self.pdf(xvals))
+            ylim = (-max_pdf * 0.075, max_pdf * 1.5)
         elif isinstance(fixed_lim, tuple):
             xlim = fixed_lim[:2]
             ylim = fixed_lim[2:]

--- a/preliz/utils/plot_utils.py
+++ b/preliz/utils/plot_utils.py
@@ -68,7 +68,7 @@ def plot_pdfpmf(dist, moments, pointinterval, quantiles, support, legend, figsiz
     if dist.kind == "continuous":
         density = dist.pdf(x)
         ax.plot(x, density, label=label, color=color)
-        ax.get_ylim()
+        ax.axhline(0, color="0.8", ls="--", zorder=0)
         ax.set_yticks([])
     else:
         mass = dist.pdf(x)
@@ -84,6 +84,7 @@ def plot_pdfpmf(dist, moments, pointinterval, quantiles, support, legend, figsiz
 
         ax.plot(x_c, mass_c, ls="dotted", color=color)
         ax.plot(x, mass, "o", label=label, color=color)
+        ax.axhline(0, color="0.8", ls="--", zorder=0)
 
     if pointinterval:
         plot_pointinterval(dist.rv_frozen, quantiles=quantiles, ax=ax)

--- a/preliz/utils/utils.py
+++ b/preliz/utils/utils.py
@@ -2,6 +2,7 @@ from sys import modules
 
 import numpy as np
 from scipy.special import gamma
+from ipywidgets import FloatSlider, IntSlider
 
 
 def hdi_from_pdf(dist, mass=0.95):
@@ -72,3 +73,33 @@ def get_pymc_to_preliz():
         zip([dist.lower() for dist in all_distributions], get_distributions(all_distributions))
     )
     return pymc_to_preliz
+
+
+def get_slider(name, value, lower, upper, continuous_update=True):
+    if np.isfinite(lower):
+        min_v = lower
+    else:
+        min_v = value - 10
+    if np.isfinite(upper):
+        max_v = upper
+    else:
+        max_v = value + 10
+
+    if isinstance(value, float):
+        slider_type = FloatSlider
+        step = (max_v - min_v) / 100
+    else:
+        slider_type = IntSlider
+        step = 1
+
+    slider = slider_type(
+        min=min_v,
+        max=max_v,
+        step=step,
+        description=f"{name} ({lower:.0f}, {upper:.0f})",
+        value=value,
+        style={"description_width": "initial"},
+        continuous_update=continuous_update,
+    )
+
+    return slider


### PR DESCRIPTION
extract function to generate sliders to avoid duplicated code in future functions. Enforce the correct parameter type. This is needed so the slider for bounded has the proper bounds