### PR TITLE
add predictive_sliders function

### DIFF
--- a/preliz/internal/parser.py
+++ b/preliz/internal/parser.py
@@ -1,0 +1,44 @@
+import re
+from sys import modules
+
+from preliz import distributions
+from .distribution_helper import init_vals
+
+
+def parse_function(source):
+    seen_distributions = {}
+    model = {}
+
+    all_distributions = modules["preliz.distributions"].__all__
+
+    all_dist_str = "|".join(all_distributions)
+
+    regex = rf"(.*?({all_dist_str}).*?)\((.*?)\)"
+    matches = re.finditer(regex, source)
+
+    for match in matches:
+        var_name = match.group(0).split("=")[0].strip()
+        dist_name_str = match.group(2)
+        args = [s.strip() for s in match.group(3).split(",")]
+        args_ = []
+        for idx, arg in enumerate(args):
+            arg = arg.strip()
+            if arg.isnumeric():
+                args_.append(float(arg))
+            else:
+                if "=" in arg:
+                    arg = arg.split("=")[1]
+                if arg in seen_distributions:
+                    args_.append(seen_distributions[arg].rvs())
+                else:
+                    args_.append(list(init_vals[dist_name_str].values())[idx])
+
+        dist = getattr(distributions, dist_name_str)
+        seen_distributions[var_name] = dist(*args_)
+        for idx, arg in enumerate(args):
+            arg = arg.strip()
+            if "=" in arg:
+                arg = arg.split("=")[1]
+            model[arg] = (dist(*args_), idx)
+
+    return model

--- a/preliz/predictive/__init__.py
+++ b/preliz/predictive/__init__.py
@@ -1,4 +1,5 @@
 from .ppa import ppa
+from .predictive_sliders import predictive_sliders
 
 
-__all__ = ["ppa"]
+__all__ = ["ppa", "predictive_sliders"]

--- a/preliz/predictive/predictive_sliders.py
+++ b/preliz/predictive/predictive_sliders.py
@@ -1,0 +1,38 @@
+import inspect
+
+from ipywidgets import interactive
+from preliz.internal.parser import parse_function
+from preliz.internal.plot_helper import get_sliders, plot_decorator
+
+
+def predictive_sliders(fmodel, samples=50, kind_plot="hist"):
+    """
+    Create sliders and plot a set of samples returned by a function relating one or more
+    PreliZ distributions.
+
+    Use this function to interactively explore how a prior predictive distribution changes when the
+    priors are changed.
+
+    Parameters
+    ----------
+    fmodel : callable
+        A function with PreliZ distributions. The distributions should call their rvs methods.
+    samples : int, optional
+        The number of samples to draw from the prior predictive distribution (default is 50).
+    kind_plot : str, optional
+        The type of plot to display. Defaults to "hist". Options are "hist" (histogram),
+        "kde" (kernel density estimate), "ecdf" (empirical cumulative distribution function),
+        or None (no plot).
+    """
+    signature = inspect.signature(fmodel)
+    source = inspect.getsource(fmodel)
+
+    model = parse_function(source)
+    sliders = get_sliders(signature, model)
+
+    if kind_plot is None:
+        new_fmodel = fmodel
+    else:
+        new_fmodel = plot_decorator(fmodel, samples, kind_plot)
+
+    return interactive(new_fmodel, **sliders)

--- a/preliz/tests/predictive_sliders.ipynb
+++ b/preliz/tests/predictive_sliders.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81849101",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import pytest\n",
+    "import ipytest\n",
+    "ipytest.autoconfig()\n",
+    "\n",
+    "import numpy as np\n",
+    "import arviz as az\n",
+    "from preliz.distributions import Normal, Gamma\n",
+    "from preliz import predictive_sliders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1630c205",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%ipytest\n",
+    "\n",
+    "x = np.linspace(0, 1, 100)\n",
+    "\n",
+    "@pytest.fixture\n",
+    "def model():\n",
+    "    def a_preliz_model(a_mu, a_sigma, c_sigma=1):\n",
+    "        a = Normal(a_mu, a_sigma).rvs()\n",
+    "        c = Gamma(mu=2, sigma=c_sigma).rvs()\n",
+    "        a = np.exp(a)\n",
+    "        b = Normal(a*x, c).rvs()\n",
+    "        return b\n",
+    "    return a_preliz_model\n",
+    "\n",
+    "@pytest.mark.parametrize(\"iterations, kind_plot\", [\n",
+    "    (50, \"hist\"),\n",
+    "    (10, \"kde\"),\n",
+    "    (10, \"ecdf\"),\n",
+    "])\n",
+    "def test_predictive_sliders(model, iterations, kind_plot):\n",
+    "    result = predictive_sliders(model, iterations, kind_plot)\n",
+    "    result._ipython_display_()\n",
+    "    slider0, slider1, slider2, plot_data = result.children\n",
+    "    slider0.value = -4\n",
+    "    slider1.value = 0.3\n",
+    "    slider2[2].value = 0.1\n",
+    "    assert 'image/png' in plot_data.outputs[0][\"data\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e006886c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "5b344a7d0839c309585d2ae27435157813d3b4ade1fa431f12bd272ea9135317"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/preliz/tests/test_predictive_sliders.py
+++ b/preliz/tests/test_predictive_sliders.py
@@ -1,0 +1,5 @@
+from test_helper import run_notebook
+
+
+def test_predictive_sliders():
+    run_notebook("predictive_sliders.ipynb")


### PR DESCRIPTION
Closes #152

The user defines a function like `a_preliz_model` and `predictive_sliders` returns an interactive plot with a set of sliders

![Captura desde 2023-01-06 14-52-54](https://user-images.githubusercontent.com/1338958/211070037-7b545a0e-7438-4bbc-9043-d786b84d3fb1.png)



![Kooha-01-06-2023-14-41-31](https://user-images.githubusercontent.com/1338958/211069532-ab72a710-60b2-4887-afbd-97b542693229.gif)


A few things to improve in the future are 
* The documentation to include at least one example of this function
* The name of the function
* The parser is very dumb, for example `a = np.exp(a)` is in it own line, because `b = pz.Normal(np.exp(a)*x, c).rvs()` will confuse the parser
* Default values for the sliders (this is true also for `plot_interactive`)
* Other options for plots