### PR TITLE
Downgrade scipy

### DIFF
--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -1152,7 +1152,7 @@ class HalfStudent(Continuous):
         optimize_ml(self, sample)
 
 
-class _HalfStudent(stats._distn_infrastructure.rv_continuous):
+class _HalfStudent(stats.rv_continuous):
     def __init__(self, nu=None, sigma=None):
         super().__init__()
         self.nu = nu

--- a/preliz/internal/plot_helper.py
+++ b/preliz/internal/plot_helper.py
@@ -9,7 +9,7 @@ from arviz import plot_kde
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import _pylab_helpers, get_backend
-from scipy.stats._distn_infrastructure import rv_continuous_frozen, rv_discrete_frozen
+from scipy.stats._distn_infrastructure import rv_frozen
 from scipy.interpolate import interp1d, PchipInterpolator
 
 _log = logging.getLogger("preliz")
@@ -33,7 +33,7 @@ def plot_pointinterval(distribution, quantiles=None, rotated=False, ax=None):
     if quantiles is None:
         quantiles = [0.05, 0.25, 0.5, 0.75, 0.95]
 
-    if isinstance(distribution, (rv_continuous_frozen, rv_discrete_frozen)):
+    if isinstance(distribution, rv_frozen):
         q_s = distribution.ppf(quantiles).tolist()
     else:
         q_s = np.quantile(distribution, quantiles).tolist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = ["version"]
 description = "The place for all your prior elicitation needs."
 dependencies = [
   "arviz",
-  "numpy>=1.20",
+  "numpy>=1.20,<1.22",
   "scipy==1.8.1",
   "matplotlib>=3.5",
   "nbclient<0.6,>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ description = "The place for all your prior elicitation needs."
 dependencies = [
   "arviz",
   "numpy>=1.20",
-  "scipy>=1.8.1",
+  "scipy==1.8.1",
   "matplotlib>=3.5",
   "nbclient<0.6,>=0.2",
   "ipywidgets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = ["version"]
 description = "The place for all your prior elicitation needs."
 dependencies = [
   "arviz",
-  "numpy>=1.22",
+  "numpy>=1.20",
   "scipy>=1.8.1",
   "matplotlib>=3.5",
   "nbclient<0.6,>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ description = "The place for all your prior elicitation needs."
 dependencies = [
   "arviz",
   "numpy>=1.22",
-  "scipy>=1.9.1",
+  "scipy>=1.8.1",
   "matplotlib>=3.5",
   "nbclient<0.6,>=0.2",
   "ipywidgets",


### PR DESCRIPTION
We no longer use `stats.fit` that was the reason to use 1.9.1. This closes #63 