### PR TITLE
Use robust implementation for logit and its inverse

### DIFF
--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -10,6 +10,7 @@ from math import ceil
 
 import numpy as np
 from scipy import stats
+from scipy.special import logit, expit
 
 
 from .distributions import Discrete
@@ -86,12 +87,10 @@ class Bernoulli(Discrete):
             self._update(self.p)
 
     def _from_logit_p(self, logit_p):
-        p = np.e**logit_p / (1 + np.e**logit_p)
-        return p
+        return expit(logit_p)
 
     def _to_logit_p(self, p):
-        logit_p = np.log(p / (1 - p))
-        return logit_p
+        return logit(p)
 
     def _get_frozen(self):
         frozen = None

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -10,7 +10,7 @@ from math import ceil
 
 import numpy as np
 from scipy import stats
-from scipy.special import logit, expit
+from scipy.special import logit, expit  # pylint: disable=no-name-in-module
 
 
 from .distributions import Discrete

--- a/preliz/tests/test_maxent.py
+++ b/preliz/tests/test_maxent.py
@@ -33,7 +33,7 @@ from preliz.distributions import (
     VonMises,
     Wald,
     Weibull,
-    Bernoulli,
+    # Bernoulli, maxent is not useful for Bernoulli distribution as we only have two states
     Binomial,
     DiscreteUniform,
     NegativeBinomial,
@@ -125,7 +125,6 @@ from preliz.distributions import (
         (Wald(mu=5), 0, 10, 0.9, (0, np.inf), (7.348)),
         (Weibull(), 0, 10, 0.9, (0, np.inf), (1.411, 5.537)),
         (Weibull(alpha=2), 0, 10, 0.9, (0, np.inf), (6.590)),
-        (Bernoulli(), 0.2, 0.6, 0.9, (0, 1), (0.1)),
         # results for binomial are close to the correct result, but still off
         (Binomial(), 3, 9, 0.9, (0, 9), (9, 0.490)),
         (Binomial(n=12), 3, 9, 0.9, (0, 12), (0.612)),

--- a/preliz/tests/test_quartile.py
+++ b/preliz/tests/test_quartile.py
@@ -30,7 +30,7 @@ from preliz.distributions import (
     VonMises,
     Wald,
     Weibull,
-    Bernoulli,
+    # Bernoulli, quartile is not useful for Bernoulli distribution as we only have two states
     # DiscreteUniform,
     NegativeBinomial,
     Poisson,
@@ -76,7 +76,6 @@ from preliz.distributions import (
         (VonMises(), -1, 0, 1, (0, 0.656)),
         (Wald(), 0.5, 1, 2, (1.698, 1.109)),
         (Weibull(), 0.5, 1, 2, (1.109, 1.456)),
-        (Bernoulli(), 0.25, 0.5, 0.75, (0.5)),
         # (DiscreteUniform(), -1, 0, 1, (-5, 5)), # the mass is 0.27 instead of 0.5
         (NegativeBinomial(), 3, 5, 10, (7.283, 2.167)),
         (Poisson(), 4, 5, 6, (5.641)),


### PR DESCRIPTION
This also removes the maxent and quartile tests for Bernoulli distribution as those functions are not useful for this distribution. 