### PR TITLE
add categorical

### DIFF
--- a/preliz/distributions/__init__.py
+++ b/preliz/distributions/__init__.py
@@ -35,6 +35,7 @@ all_discrete = [
     Bernoulli,
     BetaBinomial,
     Binomial,
+    Categorical,
     DiscreteUniform,
     Geometric,
     NegativeBinomial,

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -322,14 +322,14 @@ class Categorical(Discrete):
 
     def pdf(self, x):  # pylint: disable=arguments-differ
         x = np.asarray(x)
-        pmf = np.zeros_like(x, dtype=np.float)
+        pmf = np.zeros_like(x, dtype=float)
         valid_categories = np.where((x >= 0) & (x < len(self.p)))[0]
         pmf[valid_categories] = self.p[x[valid_categories]]
         return pmf
 
     def cdf(self, x):  # pylint: disable=arguments-differ
-        x = np.asarray(x, dtype=np.int)
-        cdf = np.ones_like(x, dtype=np.float)
+        x = np.asarray(x, dtype=int)
+        cdf = np.ones_like(x, dtype=float)
         cdf[x < 0] = 0
         valid_categories = np.where((x >= 0) & (x < len(self.p)))[0]
         cdf[valid_categories] = np.cumsum(self.p)[x[valid_categories]]

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -285,6 +285,104 @@ class Binomial(Discrete):
         self._update(n, p)
 
 
+class Categorical(Discrete):
+    R"""
+    Categorical distribution.
+
+    The most general discrete distribution. The pmf of this distribution is
+
+    .. math:: f(x \mid p) = p_x
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        from preliz import Categorical
+        az.style.use('arviz-white')
+        ps = [[0.1, 0.6, 0.3], [0.3, 0.1, 0.1, 0.5]]
+        for p in ps:
+            Categorical(p).plot_pdf()
+
+    ========  ===================================
+    Support   :math:`x \in \{0, 1, \ldots, |p|-1\}`
+    ========  ===================================
+
+    Parameters
+    ----------
+    p : array of floats
+        p > 0 and the elements of p must sum to 1.
+    logit_p : float
+        Alternative log odds for the probability of success.
+    """
+
+    def __init__(self, p=None, logit_p=None):
+        super().__init__()
+        self.dist = copy(stats.multinomial)
+        self._parametrization(p, logit_p)
+
+    def pdf(self, x):  # pylint: disable=arguments-differ
+        x = np.asarray(x)
+        pmf = np.zeros_like(x, dtype=np.float)
+        valid_categories = np.where((x >= 0) & (x < len(self.p)))[0]
+        pmf[valid_categories] = self.p[x[valid_categories]]
+        return pmf
+
+    def cdf(self, x):  # pylint: disable=arguments-differ
+        x = np.asarray(x, dtype=np.int)
+        cdf = np.ones_like(x, dtype=np.float)
+        cdf[x < 0] = 0
+        valid_categories = np.where((x >= 0) & (x < len(self.p)))[0]
+        cdf[valid_categories] = np.cumsum(self.p)[x[valid_categories]]
+        return cdf
+
+    def ppf(self, q):  # pylint: disable=arguments-differ
+        cumsum = np.cumsum(self.p)
+        return np.searchsorted(cumsum, q)
+
+    def _parametrization(self, p=None, logit_p=None):
+        if p is not None and logit_p is not None:
+            raise ValueError("Incompatible parametrization. Either use p or logit_p.")
+
+        self.param_names = "p"
+        self.params_support = ((eps, np.inf),)
+
+        if logit_p is not None:
+            p = self._from_logit_p(logit_p)
+            self.param_names = ("logit_p",)
+
+        self.p = p
+        self.logit_p = logit_p
+        if self.p is not None:
+            self.support = (0, len(p) - 1)
+            self._update(self.p)
+
+    def _from_logit_p(self, logit_p):
+        return expit(logit_p)
+
+    def _to_logit_p(self, p):
+        return logit(p)
+
+    def _get_frozen(self):
+        frozen = None
+        if all_not_none(self):
+            frozen = self.dist(n=1, p=self.p)
+        return frozen
+
+    def _update(self, p):
+        self.p = np.array(p)
+        self.logit_p = self._to_logit_p(p)
+
+        if self.param_names[0] == "p":
+            self.params = (self.p,)
+        elif self.param_names[0] == "logit_p":
+            self.params = (self.logit_p,)
+
+        self._update_rv_frozen()
+
+    def _fit_mle(self, sample):
+        optimize_ml(self, sample)
+
+
 class DiscreteUniform(Discrete):
     R"""
     Discrete Uniform distribution.

--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -65,10 +65,20 @@ def valid_scalar_params(self, check_frozen=True):
     if self.kind not in ["discrete", "continuous"]:
         return True
 
-    if all(isinstance(param, (int, float, np.int64)) for param in self.params):
+    if (
+        all(isinstance(param, (int, float, np.int64)) for param in self.params)
+        or self.__class__.__name__ == "Categorical"
+    ):
         return True
 
     raise ValueError("parameters must be integers or floats")
+
+
+def valid_distribution(self):
+    if self.__class__.__name__ != "Categorical":
+        return True
+
+    raise ValueError(f"{self.__class__.__name__} is not supported")
 
 
 init_vals = {
@@ -103,6 +113,7 @@ init_vals = {
     "Bernoulli": {"p": 0.5},
     "BetaBinomial": {"alpha": 2, "beta": 2, "n": 10},
     "Binomial": {"n": 5, "p": 0.5},
+    "Categorical": {"p": [0.5, 0.1, 0.4]},
     "DiscreteUniform": {"lower": -2.0, "upper": 2.0},
     "Geometric": {"p": 0.5},
     "NegativeBinomial": {"mu": 5.0, "alpha": 2.0},

--- a/preliz/unidimensional/maxent.py
+++ b/preliz/unidimensional/maxent.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..distributions import Normal
+from ..internal.distribution_helper import valid_distribution
 from ..internal.optimization import relative_error, optimize_max_ent, get_fixed_params
 
 _log = logging.getLogger("preliz")
@@ -71,6 +72,7 @@ def maxent(
         >>> pz.maxent(pz.HalfStudent(nu=4), 0, 12, 0.9)
 
     """
+    valid_distribution(distribution)
     if not 0 < mass <= 1:
         raise ValueError("mass should be larger than 0 and smaller or equal to 1")
 

--- a/preliz/unidimensional/mle.py
+++ b/preliz/unidimensional/mle.py
@@ -2,6 +2,7 @@ import logging
 import numpy as np
 
 from ..internal.optimization import fit_to_sample
+from ..internal.distribution_helper import valid_distribution
 
 _log = logging.getLogger("preliz")
 
@@ -37,6 +38,9 @@ def mle(
     idx : array with the indexes to sort ``distributions`` from best to worst match
     axes : matplotlib axes
     """
+    for dist in distributions:
+        valid_distribution(dist)
+
     sample = np.array(sample)
     x_min = sample.min()
     x_max = sample.max()

--- a/preliz/unidimensional/quartile.py
+++ b/preliz/unidimensional/quartile.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..distributions import Normal
+from ..internal.distribution_helper import valid_distribution
 from ..internal.optimization import relative_error, optimize_quartile, get_fixed_params
 
 _log = logging.getLogger("preliz")
@@ -70,6 +71,8 @@ def quartile(
         >>> pz.quartile(pz.HalfStudent(nu=7), 2, 9, 12)
 
     """
+    valid_distribution(distribution)
+
     if plot_kwargs is None:
         plot_kwargs = {}
 


### PR DESCRIPTION
This adds the Categorical distribution. This distribution has many peculiarities compared to other distributions already defined in PreliZ, like not having a defined cdf or moments. For the current implementation, we actually return a cdf (assuming ordered categories) but methods such as eti, hdi, summary and functions like maxent, quartiles, and mle are disabled for this distribution.

To handle these restrictions and peculiarities now the code is a little bit more patchy in some places, I prefer to leave it like that for now and defer a more clean approach once we implement multivariate distributions.

- [x] Code style is correct (follows pylint and black guidelines)
- [x] New features are properly documented (with an example if appropriate)
