### PR TITLE
add optimize_moments internal function

### DIFF
--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -12,7 +12,7 @@ from scipy import stats
 from scipy.special import gamma as gammaf
 from scipy.special import logit, expit  # pylint: disable=no-name-in-module
 
-from ..internal.optimization import optimize_ml
+from ..internal.optimization import optimize_ml, optimize_moments
 from ..internal.distribution_helper import garcia_approximation, all_not_none
 from .distributions import Continuous
 
@@ -2066,7 +2066,8 @@ class Rice(Continuous):
         self._update_rv_frozen()
 
     def _fit_moments(self, mean, sigma):
-        self._update(mean, sigma)
+        params = mean, sigma
+        optimize_moments(self, mean, sigma, params)
 
     def _fit_mle(self, sample, **kwargs):
         b, _, sigma = self.dist.fit(sample, **kwargs)

--- a/preliz/distributions/discrete.py
+++ b/preliz/distributions/discrete.py
@@ -15,7 +15,7 @@ from scipy.special import logit, expit  # pylint: disable=no-name-in-module
 
 
 from .distributions import Discrete
-from ..internal.optimization import optimize_ml
+from ..internal.optimization import optimize_ml, optimize_moments
 from ..internal.distribution_helper import all_not_none
 
 
@@ -199,7 +199,8 @@ class BetaBinomial(Discrete):
         rho = ((sigma**2 / (mean * (1 - p))) - 1) / (n - 1)
         alpha = max(0.5, (p / rho) - p)
         beta = max(0.5, (alpha / p) - alpha)
-        self._update(alpha, beta, n)
+        params = alpha, beta, n
+        optimize_moments(self, mean, sigma, params)
 
     def _fit_mle(self, sample):
         optimize_ml(self, sample)
@@ -274,7 +275,8 @@ class Binomial(Discrete):
         # crude approximation for n and p
         n = mean + sigma * 2
         p = mean / n
-        self._update(n, p)
+        params = n, p
+        optimize_moments(self, mean, sigma, params)
 
     def _fit_mle(self, sample):
         # see https://doi.org/10.1016/j.jspi.2004.02.019 for details

--- a/preliz/tests/test_maxent.py
+++ b/preliz/tests/test_maxent.py
@@ -96,7 +96,7 @@ from preliz.distributions import (
         (Normal(mu=0.5), -1, 1, 0.8, (-np.inf, np.inf), (0.581)),
         (Pareto(), 1, 4, 0.9, (1, np.inf), (1.660, 1)),
         (Pareto(m=2), 1, 4, 0.9, (2, np.inf), (3.321)),
-        (Rice(), 0, 4, 0.7, (0, np.inf), (0.027, 2.577)),
+        (Rice(), 0, 4, 0.7, (0, np.inf), (0.028, 2.577)),
         (Rice(nu=4), 0, 6, 0.9, (0, np.inf), (1.402)),
         (SkewNormal(), -2, 10, 0.9, (-np.inf, np.inf), (3.999, 3.647, 0)),
         (SkewNormal(mu=-1), -2, 10, 0.9, (-np.inf, np.inf), (6.2924, 4.905)),
@@ -138,7 +138,7 @@ from preliz.distributions import (
         (BetaBinomial(n=10), 2, 6, 0.6, (0, 10), (1.837, 2.181)),
         # results for binomial are close to the correct result, but still off
         (Binomial(), 3, 9, 0.9, (0, 9), (9, 0.490)),
-        (Binomial(n=12), 3, 9, 0.9, (0, 12), (0.612)),
+        (Binomial(n=12), 3, 9, 0.9, (0, 12), (0.387)),
         (DiscreteUniform(), -2, 10, 0.9, (-3, 11), (-2, 10)),
         (Geometric(), 1, 4, 0.99, (0, np.inf), (0.6837)),
         (NegativeBinomial(), 0, 15, 0.9, (0, np.inf), (7.546, 2.041)),


### PR DESCRIPTION
This PR adds an internal function to better approximate the moments, that we later use to initialize maxent. 

- [x] Code style is correct (follows pylint and black guidelines)
- [x] Includes new or updated tests to cover the new feature
