### PR TITLE
Add initial support for MultiVariate Variables

### DIFF
--- a/preliz/distributions/__init__.py
+++ b/preliz/distributions/__init__.py
@@ -1,5 +1,6 @@
 from .continuous import *
 from .discrete import *
+from .continuous_multivariate import *
 
 all_continuous = [
     AsymmetricLaplace,
@@ -47,5 +48,11 @@ all_discrete = [
     ZeroInflatedPoisson,
 ]
 
+all_continuous_multivariate = [Dirichlet, MvNormal]
 
-__all__ = [s.__name__ for s in all_continuous] + [s.__name__ for s in all_discrete]
+
+__all__ = (
+    [s.__name__ for s in all_continuous]
+    + [s.__name__ for s in all_discrete]
+    + [s.__name__ for s in all_continuous_multivariate]
+)

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy import stats
 
 from .distributions_multivariate import Continuous
+from .continuous import Beta, Normal
 from ..internal.distribution_helper import all_not_none
 from ..internal.plot_helper_multivariate import plot_dirichlet, plot_mvnormal
 
@@ -57,6 +58,7 @@ class Dirichlet(Continuous):
     def __init__(self, alpha=None):
         super().__init__()
         self.dist = copy(stats.dirichlet)
+        self.marginal = Beta
         self.support = (eps, 1 - eps)
         self._parametrization(alpha)
 
@@ -243,6 +245,7 @@ class MvNormal(Continuous):
     def __init__(self, mu=None, cov=None):
         super().__init__()
         self.dist = copy(stats.multivariate_normal)
+        self.marginal = Normal
         self.support = (-np.inf, np.inf)
         self._parametrization(mu, cov)
 

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -96,16 +96,16 @@ class Dirichlet(Continuous):
     ):
         """
         Plot the pdf of the marginals or the joint pdf of the simplex.
-        The joint representation is only available for a dirichlet with a alpha of length 3.
+        The joint representation is only available for a dirichlet with an alpha of length 3.
 
         Parameters
         ----------
         marginals : True
-            Defaults to True, plor the marginal distributions, if False plot the joint distribution
+            Defaults to True, plot the marginal distributions, if False plot the joint distribution
             (only valid for an alpha of length 3).
         pointinterval : bool
             Whether to include a plot of the quantiles. Defaults to False. If True the default is to
-            plot the median and two interquantiles ranges.
+            plot the median and two interquantile ranges.
         interval : str
             Type of interval. Available options are highest density interval `"hdi"` (default),
         equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
@@ -117,7 +117,7 @@ class Dirichlet(Continuous):
             If ``full`` use the finite end-points to set the limits of the plot. For unbounded
             end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
         figsize : tuple
-            Size of the
+            Size of the figure
         ax : matplotlib axis
             Axis to plot on
 
@@ -145,7 +145,7 @@ class Dirichlet(Continuous):
         ----------
         pointinterval : bool
             Whether to include a plot of the quantiles. Defaults to False. If True the default is to
-            plot the median and two interquantiles ranges.
+            plot the median and two interquantile ranges.
         interval : str
             Type of interval. Available options are highest density interval `"hdi"` (default),
         equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
@@ -236,9 +236,9 @@ class MvNormal(Continuous):
 
     Parameters
     ----------
-    mu : tensor_like of float
+    mu : array of floats
         Vector of means.
-    cov : tensor_like of float, optional
+    cov : array of floats, optional
         Covariance matrix.
     """
 
@@ -285,13 +285,13 @@ class MvNormal(Continuous):
         ax=None,
     ):
         """
-        Plot the  pdf of the marginals or the joint pdf
+        Plot the pdf of the marginals or the joint pdf
         The joint representation is only available for a 2D Multivariate Normal.
 
         Parameters
         ----------
         marginals : True
-            Defaults to True, plor the marginal distributions, if False plot the joint distribution
+            Defaults to True, plot the marginal distributions, if False plot the joint distribution
             (only valid for a bivariate normal).
         pointinterval : bool
             Whether to include a plot of the quantiles. Defaults to False. If True the default is to

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -95,7 +95,7 @@ class Dirichlet(Continuous):
         ax=None,
     ):
         """
-        Plot the  pdf of the marginals or the joint pdf on the simplex.
+        Plot the pdf of the marginals or the joint pdf of the simplex.
         The joint representation is only available for a dirichlet with a alpha of length 3.
 
         Parameters

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -184,7 +184,7 @@ class Dirichlet(Continuous):
         ----------
         pointinterval : bool
             Whether to include a plot of the quantiles. Defaults to False. If True the default is to
-            plot the median and two interquantiles ranges.
+            plot the median and two interquantile ranges.
         interval : str
             Type of interval. Available options are highest density interval `"hdi"` (default),
         equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -1,0 +1,393 @@
+# pylint: disable=too-many-lines
+# pylint: disable=too-many-instance-attributes
+# pylint: disable=invalid-name
+# pylint: disable=attribute-defined-outside-init
+"""
+Continuous multivariate probability distributions.
+"""
+from copy import copy
+
+import numpy as np
+from scipy import stats
+
+from .distributions_multivariate import Continuous
+from ..internal.distribution_helper import all_not_none
+from ..internal.plot_helper_multivariate import plot_dirichlet, plot_mvnormal
+
+
+eps = np.finfo(float).eps
+
+
+class Dirichlet(Continuous):
+    r"""
+    Dirichlet distribution.
+
+    .. math::
+
+       f(\mathbf{x}|\mathbf{a}) =
+           \frac{\Gamma(\sum_{i=1}^k a_i)}{\prod_{i=1}^k \Gamma(a_i)}
+           \prod_{i=1}^k x_i^{a_i - 1}
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        import matplotlib.pyplot as plt
+        from preliz import Dirichlet
+        _, axes = plt.subplots(2, 2)
+        alphas = [[0.5, 0.5, 0.5], [1, 1, 1], [5, 5, 5], [5, 2, 1]]
+        for alpha, ax in zip(alphas, axes.ravel()):
+            pz.Dirichlet(alpha).plot_pdf(marginals=False, ax=ax)
+
+
+    ========  ===============================================
+    Support   :math:`x_i \in (0, 1)` for :math:`i \in \{1, \ldots, K\}`
+              such that :math:`\sum x_i = 1`
+    Mean      :math:`\dfrac{a_i}{\sum a_i}`
+    Variance  :math:`\dfrac{a_i - \sum a_0}{a_0^2 (a_0 + 1)}`
+              where :math:`a_0 = \sum a_i`
+    ========  ===============================================
+
+    Parameters
+    ----------
+    alpha : array of floats
+        Concentration parameter (alpha > 0).
+    """
+
+    def __init__(self, alpha=None):
+        super().__init__()
+        self.dist = copy(stats.dirichlet)
+        self.support = (eps, 1 - eps)
+        self._parametrization(alpha)
+
+    def _parametrization(self, alpha=None):
+        self.param_names = "alpha"
+        self.params_support = ((eps, np.inf),)
+
+        self.alpha = alpha
+        if alpha is not None:
+            self._update(alpha)
+
+    def _get_frozen(self):
+        frozen = None
+        if all_not_none(self):
+            frozen = self.dist(self.alpha)
+        return frozen
+
+    def _update(self, alpha):
+        self.alpha = np.array(alpha, dtype=float)
+        self.params = (self.alpha,)
+        self._update_rv_frozen()
+
+    def _fit_mle(self, sample, **kwargs):
+        raise NotImplementedError
+
+    def plot_pdf(
+        self,
+        marginals=True,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        support="full",
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the  pdf of the marginals or the joint pdf on the simplex.
+        The joint representation is only available for a dirichlet with a alpha of length 3.
+
+        Parameters
+        ----------
+        marginals : True
+            Defaults to True, plor the marginal distributions, if False plot the joint distribution
+            (only valid for an alpha of length 3).
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        support : str:
+            If ``full`` use the finite end-points to set the limits of the plot. For unbounded
+            end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
+        figsize : tuple
+            Size of the
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_dirichlet(
+            self, "pdf", marginals, pointinterval, interval, levels, support, figsize, ax
+        )
+
+    def plot_cdf(
+        self,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        support="full",
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the cumulative distribution function.
+
+        Parameters
+        ----------
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        support : str:
+            If ``full`` use the finite end-points to set the limits of the plot. For unbounded
+            end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
+        figsize : tuple
+            Size of the figure
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_dirichlet(
+            self, "cdf", "marginals", pointinterval, interval, levels, support, figsize, ax
+        )
+
+    def plot_ppf(
+        self,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the quantile function.
+
+        Parameters
+        ----------
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        figsize : tuple
+            Size of the figure
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_dirichlet(
+            self, "ppf", "marginals", pointinterval, interval, levels, None, figsize, ax
+        )
+
+
+class MvNormal(Continuous):
+    r"""
+    Multivariate Normal distribution.
+
+    .. math::
+
+       f(x \mid \pi, T) =
+           \frac{|T|^{1/2}}{(2\pi)^{k/2}}
+           \exp\left\{ -\frac{1}{2} (x-\mu)^{\prime} T (x-\mu) \right\}
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        import matplotlib.pyplot as plt
+        from preliz import MvNormal
+        _, axes = plt.subplots(2, 2, figsize=(9, 9), sharex=True, sharey=True)
+        mus = [[0., 0], [3, -2], [0., 0], [0., 0]]
+        sigmas = [np.eye(2), np.eye(2), np.array([[2, 2], [2, 4]]), np.array([[2, -2], [-2, 4]])]
+        for mu, sigma, ax in zip(mus, sigmas, axes.ravel()):
+            pz.MvNormal(mu, sigma).plot_pdf(marginals=False, ax=ax)
+
+    ========  ==========================
+    Support   :math:`x \in \mathbb{R}^k`
+    Mean      :math:`\mu`
+    Variance  :math:`T^{-1}`
+    ========  ==========================
+
+    Parameters
+    ----------
+    mu : tensor_like of float
+        Vector of means.
+    cov : tensor_like of float, optional
+        Covariance matrix.
+    """
+
+    def __init__(self, mu=None, cov=None):
+        super().__init__()
+        self.dist = copy(stats.multivariate_normal)
+        self.support = (-np.inf, np.inf)
+        self._parametrization(mu, cov)
+
+    def _parametrization(self, mu=None, cov=None):
+        self.param_names = ("mu", "cov")
+        self.params_support = ((eps, np.inf), (eps, np.inf))
+
+        self.mu = mu
+        self.cov = cov
+        if mu is not None and cov is not None:
+            self._update(mu, cov)
+
+    def _get_frozen(self):
+        frozen = None
+        if all_not_none(self):
+            frozen = self.dist(mean=self.mu, cov=self.cov)
+        return frozen
+
+    def _update(self, mu, cov):
+        self.mu = np.array(mu, dtype=float)
+        self.cov = np.array(cov, dtype=float)
+        self.params = (mu, cov)
+        self._update_rv_frozen()
+        self.rv_frozen.var = lambda: np.diag(self.cov)
+
+    def _fit_mle(self, sample, **kwargs):
+        raise NotImplementedError
+
+    def plot_pdf(
+        self,
+        marginals=True,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        support="full",
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the  pdf of the marginals or the joint pdf
+        The joint representation is only available for a 2D Multivariate Normal.
+
+        Parameters
+        ----------
+        marginals : True
+            Defaults to True, plor the marginal distributions, if False plot the joint distribution
+            (only valid for a bivariate normal).
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        support : str:
+            If ``full`` use the finite end-points to set the limits of the plot. For unbounded
+            end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
+        figsize : tuple
+            Size of the figure
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_mvnormal(
+            self, "pdf", marginals, pointinterval, interval, levels, support, figsize, ax
+        )
+
+    def plot_cdf(
+        self,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        support="full",
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the cumulative distribution function.
+
+        Parameters
+        ----------
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        support : str:
+            If ``full`` use the finite end-points to set the limits of the plot. For unbounded
+            end-points or if ``restricted`` use the 0.001 and 0.999 quantiles to set the limits.
+        figsize : tuple
+            Size of the figure
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_mvnormal(
+            self, "cdf", "marginals", pointinterval, interval, levels, support, figsize, ax
+        )
+
+    def plot_ppf(
+        self,
+        pointinterval=False,
+        interval="hdi",
+        levels=None,
+        figsize=None,
+        ax=None,
+    ):
+        """
+        Plot the quantile function.
+
+        Parameters
+        ----------
+        pointinterval : bool
+            Whether to include a plot of the quantiles. Defaults to False. If True the default is to
+            plot the median and two interquantiles ranges.
+        interval : str
+            Type of interval. Available options are highest density interval `"hdi"` (default),
+        equal tailed interval `"eti"` or intervals defined by arbitrary `"quantiles"`.
+        levels : list
+            Mass of the intervals. For hdi or eti the number of elements should be 2 or 1.
+            For quantiles the number of elements should be 5, 3, 1 or 0
+            (in this last case nothing will be plotted).
+        figsize : tuple
+            Size of the figure
+        ax : matplotlib axis
+            Axis to plot on
+
+        Returns
+        -------
+        ax : matplotlib axis
+        """
+        return plot_mvnormal(
+            self, "ppf", "marginals", pointinterval, interval, levels, None, figsize, ax
+        )

--- a/preliz/distributions/distributions_multivariate.py
+++ b/preliz/distributions/distributions_multivariate.py
@@ -1,0 +1,220 @@
+"""
+Parent classes for multivariate families.
+"""
+# pylint: disable=no-member
+from collections import namedtuple
+
+import numpy as np
+from scipy.special import betainc
+
+from ..internal.distribution_helper import (
+    valid_scalar_params,
+    valid_distribution,
+)
+
+
+class Multivariate:
+    """
+    Base class for Multivariate distributions.
+
+    Not intended for direct instantiation.
+    """
+
+    def __init__(self):
+        self.rv_frozen = None
+        self.is_frozen = False
+        self.opt = None
+
+    def __repr__(self):
+        name = self.__class__.__name__
+        if self.is_frozen:
+            bolded_name = "\033[1m" + name + "\033[0m"
+
+            description = "".join(
+                f"{n}={np.round(v, 2)}," for n, v in zip(self.param_names, self.params)
+            ).strip(",")
+
+            return f"{bolded_name}({description})"
+        else:
+            return name
+
+    def _update_rv_frozen(self):
+        """Update the rv_frozen object"""
+
+        frozen = self._get_frozen()
+        if frozen is not None:
+            self.is_frozen = True
+            self.rv_frozen = frozen
+
+    def summary(self):
+        """
+        Namedtuple with the mean, and standard deviation of the distribution.
+        """
+        valid_distribution(self)
+
+        if valid_scalar_params(self):
+            attr = namedtuple(self.__class__.__name__, ["mean", "std"])
+            if self.__class__.__name__ == "MvNormal":
+                # for some weird reason, the mean of mvnormal is an attribute
+                # and not a method like for the rest of the distributions
+                mean = self.rv_frozen.mean
+            else:
+                mean = self.rv_frozen.mean()
+            std = self.rv_frozen.var() ** 0.5
+            return attr(mean, std)
+        else:
+            return None
+
+    def rvs(self, *args, **kwds):
+        """Random sample
+
+        Parameters
+        ----------
+        size : int or tuple of ints, optional
+            Defining number of random variates. Defaults to 1.
+        random_state : {None, int, numpy.random.Generator, numpy.random.RandomState}
+            Defaults to None
+        """
+        return self.rv_frozen.rvs(*args, **kwds)
+
+    def cdf(self, x):
+        """Cumulative distribution function.
+
+        Parameters
+        ----------
+        x : array_like
+            Values on which to evaluate the cdf
+        """
+        # not sure if this is right
+        return betainc(self.alpha, self.alpha.sum(), x)
+
+    def _check_endpoints(self, lower, upper, raise_error=True):
+        """
+        Evaluate if the lower and upper values are in the support of the distribution
+
+        Parameters
+        ----------
+        lower : int or float
+            lower endpoint
+        upper : int or float
+            upper endpoint
+        raise_error : bool
+            If True (default) it will raise ValueErrors, otherwise it will return True
+            if the lower and upper endpoint are in the support of the distribution or
+            False otherwise.
+        """
+        s_l, s_u = self.support
+
+        if raise_error:
+            domain_error = (
+                f"The provided endpoints are outside the domain of the "
+                f"{self.__class__.__name__} distribution"
+            )
+
+            if np.isfinite(s_l):
+                if lower < s_l:
+                    raise ValueError(domain_error)
+
+            if np.isfinite(s_u):
+                if upper > s_u:
+                    raise ValueError(domain_error)
+            if np.isfinite(s_l) and np.isfinite(s_u):
+                if lower == s_l and upper == s_u:
+                    raise ValueError(
+                        "Given the provided endpoints, mass will be always 1. "
+                        "Please provide other values"
+                    )
+            return None
+        else:
+            return lower >= s_l and upper <= s_u
+
+    def _finite_endpoints(self, support):
+        """
+        Return finite endpoints even for unbounded distributions
+
+        Parameters
+        ----------
+        support : str or tuple
+            Available string options are "full" or "restricted".
+        """
+        if isinstance(support, tuple):
+            lower_ep, upper_ep = support
+        else:
+            lower_ep, upper_ep = self.support
+
+            if not np.isfinite(lower_ep) or support == "restricted":
+                lower_ep = self.ppf(0.0001)
+            if not np.isfinite(upper_ep) or support == "restricted":
+                upper_ep = self.ppf(0.9999)
+
+        return lower_ep, upper_ep
+
+
+class Continuous(Multivariate):
+    """Base class for continuous multivariate distributions."""
+
+    def __init__(self):
+        super().__init__()
+        self.kind = "continuous_multivariate"
+
+    def xvals(self, support):
+        """Provide x values in the support of the distribution. This is useful for example when
+        plotting.
+
+        Parameters
+        ----------
+        support : str
+            Available options are "full" or "restricted".
+        """
+        lower_ep, upper_ep = self._finite_endpoints(support)
+        x_vals = np.linspace(lower_ep, upper_ep, 1000)
+        return x_vals
+
+    def _fit_mle(self, sample, **kwargs):
+        """
+        Estimate the parameters of the distribution from a sample by maximizing the likelihood.
+
+        Parameters
+        ----------
+        sample : array-like
+            a sample
+        kwargs : dict
+            keywords arguments passed to scipy.stats.rv_continuous.fit
+        """
+        raise NotImplementedError
+
+    def pdf(self, x):
+        """Probability density function at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Values on which to evaluate the pdf
+        """
+        return self.rv_frozen.pdf(x)
+
+
+class Discrete(Multivariate):
+    """Base class for discrete distributions."""
+
+    def __init__(self):
+        super().__init__()
+        self.kind = "discrete"
+
+    def xvals(self, support):
+        """Provide x values in the support of the distribution. This is useful for example when
+        plotting.
+        """
+        lower_ep, upper_ep = self._finite_endpoints(support)
+        x_vals = np.arange(lower_ep, upper_ep + 1, dtype=int)
+        return x_vals
+
+    def pdf(self, x, *args, **kwds):
+        """Probability mass function at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Values on which to evaluate the pdf
+        """
+        return self.rv_frozen.pmf(x, *args, **kwds)

--- a/preliz/distributions/distributions_multivariate.py
+++ b/preliz/distributions/distributions_multivariate.py
@@ -5,7 +5,7 @@ Parent classes for multivariate families.
 from collections import namedtuple
 
 import numpy as np
-from scipy.special import betainc
+from scipy.special import betainc  # pylint: disable=no-name-in-module
 
 from ..internal.distribution_helper import (
     valid_scalar_params,

--- a/preliz/internal/plot_helper_multivariate.py
+++ b/preliz/internal/plot_helper_multivariate.py
@@ -5,7 +5,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import tri
 from scipy.special import gamma
-import preliz as pz
 from .plot_helper import repr_to_matplotlib
 
 
@@ -118,7 +117,7 @@ def plot_dirichlet(
 
         for a_i, ax in zip(alpha, axes):
             if representation == "pdf":
-                pz.Beta(a_i, a_0 - a_i).plot_pdf(
+                dist.marginal(a_i, a_0 - a_i).plot_pdf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,
@@ -127,7 +126,7 @@ def plot_dirichlet(
                     ax=ax,
                 )
             elif representation == "cdf":
-                pz.Beta(a_i, a_0 - a_i).plot_cdf(
+                dist.marginal(a_i, a_0 - a_i).plot_cdf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,
@@ -136,7 +135,7 @@ def plot_dirichlet(
                     ax=ax,
                 )
             elif representation == "ppf":
-                pz.Beta(a_i, a_0 - a_i).plot_ppf(
+                dist.marginal(a_i, a_0 - a_i).plot_ppf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,
@@ -228,7 +227,7 @@ def plot_mvnormal(
 
         for mu_i, sigma_i, ax in zip(mu, sigma, axes):
             if representation == "pdf":
-                pz.Normal(mu_i, sigma_i).plot_pdf(
+                dist.marginal(mu_i, sigma_i).plot_pdf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,
@@ -237,7 +236,7 @@ def plot_mvnormal(
                     ax=ax,
                 )
             elif representation == "cdf":
-                pz.Normal(mu_i, sigma_i).plot_cdf(
+                dist.marginal(mu_i, sigma_i).plot_cdf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,
@@ -246,7 +245,7 @@ def plot_mvnormal(
                     ax=ax,
                 )
             elif representation == "ppf":
-                pz.Normal(mu_i, sigma_i).plot_ppf(
+                dist.marginal(mu_i, sigma_i).plot_ppf(
                     pointinterval=pointinterval,
                     interval=interval,
                     levels=levels,

--- a/preliz/internal/plot_helper_multivariate.py
+++ b/preliz/internal/plot_helper_multivariate.py
@@ -1,0 +1,266 @@
+from functools import reduce
+from operator import mul
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib import tri
+from scipy.special import gamma
+import preliz as pz
+from .plot_helper import repr_to_matplotlib
+
+
+def get_cols_rows(n_plots):
+    """Get number of columns and rows for a grid of plots."""
+    if n_plots <= 3:
+        return 1, n_plots
+    else:
+        rows = int(np.ceil(n_plots / 3))
+        return 3, rows
+
+
+class DirichletOnSimplex:
+    def __init__(self, alpha):
+        """Creates Dirichlet distribution with parameter `alpha`.
+
+        Adapted from Thomas Boggs' blogpost
+        https://blog.bogatron.net/blog/2014/02/02/visualizing-dirichlet-distributions/
+        """
+
+        self._alpha = np.array(alpha)
+        self._coef = gamma(np.sum(self._alpha)) / reduce(mul, [gamma(a) for a in self._alpha])
+
+        self._corners = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 0.75**0.5]])
+        self._triangle = tri.Triangulation(self._corners[:, 0], self._corners[:, 1])
+        self._midpoints = [
+            (self._corners[(i + 1) % 3] + self._corners[(i + 2) % 3]) / 2.0 for i in range(3)
+        ]
+
+    def xy2bc(self, x_y, tol=1.0e-3):
+        """
+        Converts 2D Cartesian coordinates to barycentric coordinates.
+
+        Parameters
+        ----------
+        xy : A length-2 sequence containing the x and y value.
+        """
+        bsc = [
+            (self._corners[i] - self._midpoints[i]).dot(x_y - self._midpoints[i]) / 0.75
+            for i in range(3)
+        ]
+        return np.clip(bsc, tol, 1.0 - tol)
+
+    def pdf(self, x):
+        """Returns pdf value for `x`."""
+        return self._coef * reduce(mul, [xx ** (aa - 1) for (xx, aa) in zip(x, self._alpha)])
+
+    def plot(self, ax=None):
+        """
+        Draws pdf contours over the 2-simplex.
+
+        Parameters
+        ----------
+        dist : A distribution instance with a `pdf` method.
+        nlevels: int
+            Number of contours to draw.
+        subdiv: int
+            Number of recursive mesh subdivisions to create.
+        """
+        refiner = tri.UniformTriRefiner(self._triangle)
+        trimesh = refiner.refine_triangulation(subdiv=8)
+        pvals = [self.pdf(self.xy2bc(xy)) for xy in zip(trimesh.x, trimesh.y)]
+
+        hdi_probs = [0.1, 0.5, 0.94]
+        contour_levels = find_hdi_contours(pvals, hdi_probs)
+        if all(contour_levels == contour_levels[0]):
+            ax.tricontourf(trimesh, pvals)
+        else:
+            ax.tricontour(
+                trimesh,
+                pvals,
+                levels=contour_levels,
+            )
+            ax.triplot(self._triangle, color="0.8", linestyle="--", linewidth=2)
+        ax.axis("equal")
+        ax.set_xlim(0, 1)
+        ax.set_ylim(0, 0.75**0.5)
+        ax.axis("off")
+
+
+def plot_dirichlet(
+    dist,
+    representation,
+    marginals,
+    pointinterval,
+    interval,
+    levels,
+    support,
+    figsize,
+    axes,
+):
+    """Plot pdf, cdf or ppf of Dirichlet distribution."""
+
+    alpha = dist.alpha
+    dim = len(alpha)
+
+    if figsize is None:
+        figsize = (12, 4)
+
+    if marginals:
+        a_0 = alpha.sum()
+        cols, rows = get_cols_rows(dim)
+
+        if axes is None:
+            fig, axes = plt.subplots(cols, rows, figsize=figsize, sharex=True, sharey=True)
+            axes = axes.flatten()
+        if len(axes) > dim:
+            for ax in axes[dim:]:
+                ax.remove()
+
+        for a_i, ax in zip(alpha, axes):
+            if representation == "pdf":
+                pz.Beta(a_i, a_0 - a_i).plot_pdf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    support=support,
+                    legend=False,
+                    ax=ax,
+                )
+            elif representation == "cdf":
+                pz.Beta(a_i, a_0 - a_i).plot_cdf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    support=support,
+                    legend=False,
+                    ax=ax,
+                )
+            elif representation == "ppf":
+                pz.Beta(a_i, a_0 - a_i).plot_ppf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    legend=False,
+                    ax=ax,
+                )
+
+        fig.text(0.5, 1, repr_to_matplotlib(dist), ha="center", va="center")
+
+    else:
+        if dim == 3:
+            if axes is None:
+                _, axes = plt.subplots(1, 1)
+            DirichletOnSimplex(alpha).plot(ax=axes)
+            axes.set_title(repr_to_matplotlib(dist))
+        else:
+            raise ValueError("joint only works for Dirichlet of dim=3")
+
+
+def joint_normal(dist, ax):
+    """Plot pdf of joint normal distribution."""
+    x_max = dist.mu[0] + 3 * dist.cov[0, 0] ** 0.5
+    y_max = dist.mu[1] + 3 * dist.cov[1, 1] ** 0.5
+    x_min = dist.mu[0] - 3 * dist.cov[0, 0] ** 0.5
+    y_min = dist.mu[1] - 3 * dist.cov[1, 1] ** 0.5
+    x, y = np.mgrid[x_min:x_max:0.01, y_min:y_max:0.01]
+
+    pos = np.dstack((x, y))
+
+    density = dist.pdf(pos)
+    contour_levels = find_hdi_contours(density, [0.1, 0.5, 0.94])
+    ax.contour(x, y, density, levels=contour_levels)
+    ax.set_aspect("equal")
+
+
+def find_hdi_contours(density, hdi_probs):
+    """
+    Find contours enclosing regions of highest posterior density.
+
+    Parameters
+    ----------
+    density : array-like
+    hdi_probs : array-like
+        An array of highest density interval confidence probabilities.
+
+    Returns
+    -------
+    contour_levels : list
+        The contour levels corresponding to the given HDI probabilities.
+    """
+    # Using the algorithm from corner.py
+    sorted_density = np.sort(density, axis=None)[::-1]
+    csd = sorted_density.cumsum()
+    csd /= csd[-1]
+
+    contours = np.empty_like(hdi_probs)
+    for idx, hdi_prob in enumerate(hdi_probs):
+        try:
+            contours[idx] = sorted_density[csd <= hdi_prob][-1]
+        except IndexError:
+            contours[idx] = sorted_density[0]
+
+    contours.sort()
+
+    return contours
+
+
+def plot_mvnormal(
+    dist, representation, marginals, pointinterval, interval, levels, support, figsize, axes
+):
+    """Plot pdf, cdf or ppf of Multivariate Normal distribution."""
+
+    mu = dist.mu
+    sigma = dist.rv_frozen.var() ** 0.5
+    dim = len(mu)
+
+    if figsize is None:
+        figsize = (12, 4)
+
+    if marginals:
+        cols, rows = get_cols_rows(dim)
+
+        if axes is None:
+            fig, axes = plt.subplots(cols, rows, figsize=figsize, sharex=True, sharey=True)
+            axes = axes.flatten()
+        if len(axes) > dim:
+            for ax in axes[dim:]:
+                ax.remove()
+
+        for mu_i, sigma_i, ax in zip(mu, sigma, axes):
+            if representation == "pdf":
+                pz.Normal(mu_i, sigma_i).plot_pdf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    support=support,
+                    legend=False,
+                    ax=ax,
+                )
+            elif representation == "cdf":
+                pz.Normal(mu_i, sigma_i).plot_cdf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    support=support,
+                    legend=False,
+                    ax=ax,
+                )
+            elif representation == "ppf":
+                pz.Normal(mu_i, sigma_i).plot_ppf(
+                    pointinterval=pointinterval,
+                    interval=interval,
+                    levels=levels,
+                    legend=False,
+                    ax=ax,
+                )
+
+        fig.text(0.5, 1, repr_to_matplotlib(dist), ha="center", va="center")
+
+    else:
+        if dim == 2:
+            if axes is None:
+                _, axes = plt.subplots(1, 1)
+            joint_normal(dist, axes)
+            axes.set_title(repr_to_matplotlib(dist))
+        else:
+            raise ValueError("joint only works for Multivariate Normal of dim=2")

--- a/preliz/tests/test_distributions.py
+++ b/preliz/tests/test_distributions.py
@@ -43,12 +43,19 @@ from preliz.distributions import (
     Poisson,
     ZeroInflatedNegativeBinomial,
     ZeroInflatedPoisson,
+    Dirichlet,
+    MvNormal,
 )
 
 
 @pytest.fixture(scope="session")
 def a_few_poissons():
     return Poisson(), Poisson([1.0, 2.0]), Poisson(4.5)
+
+
+@pytest.fixture(scope="session")
+def multivariates():
+    return Dirichlet(), Dirichlet([1.0, 2.0, 1.0]), MvNormal(np.zeros(2), np.eye(2))
 
 
 @pytest.mark.parametrize(
@@ -188,7 +195,7 @@ def test_summary_args(fmt, mass):
     assert result.std == 1
 
 
-def test_summary_valid(a_few_poissons):
+def test_summary_univariate_valid(a_few_poissons):
     d_0, d_1, d_2 = a_few_poissons
     with pytest.raises(ValueError):
         d_0.summary()
@@ -200,6 +207,20 @@ def test_summary_valid(a_few_poissons):
     assert result.std == 2.12
     assert result.lower == 1.0
     assert result.upper == 9.0
+
+
+def test_summary_multivariate_valid(multivariates):
+    d_0, d_1, m_0 = multivariates
+    with pytest.raises(ValueError):
+        d_0.summary()
+    result = d_1.summary()
+    assert result.__class__.__name__ == "Dirichlet"
+    assert_almost_equal(result.mean, [0.25, 0.5, 0.25])
+    assert_almost_equal(result.std, [0.193, 0.223, 0.193], decimal=3)
+    result = m_0.summary()
+    assert result.__class__.__name__ == "MvNormal"
+    assert_almost_equal(result.mean, [0, 0])
+    assert_almost_equal(result.std, [1, 1])
 
 
 def test_eti(a_few_poissons):

--- a/preliz/tests/test_plots.py
+++ b/preliz/tests/test_plots.py
@@ -2,6 +2,7 @@
 # pylint: disable=redefined-outer-name
 import pytest
 import matplotlib.pyplot as plt
+import numpy as np
 
 import preliz as pz
 
@@ -37,7 +38,54 @@ def test_continuous_plot_pdf_cdf_ppf(two_dist, kwargs):
 
 def test_plot_interactive():
     for idx, distribution in enumerate(pz.distributions.__all__):
-        dist = getattr(pz.distributions, distribution)
-        kind = ["pdf", "cdf", "ppf"][idx % 3]
-        fixed_lim = ["auto", "both"][idx % 2]
-        dist().plot_interactive(kind=kind, fixed_lim=fixed_lim)
+        if distribution not in ["Dirichlet", "MvNormal"]:
+            dist = getattr(pz.distributions, distribution)
+            kind = ["pdf", "cdf", "ppf"][idx % 3]
+            fixed_lim = ["auto", "both"][idx % 2]
+            dist().plot_interactive(kind=kind, fixed_lim=fixed_lim)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"marginals": True},
+        {"pointinterval": True},
+        {"pointinterval": True, "levels": [0.1, 0.9]},
+        {"pointinterval": True, "interval": "eti", "levels": [0.9]},
+        {"pointinterval": True, "interval": "quantiles"},
+        {"pointinterval": True, "interval": "quantiles", "levels": [0.1, 0.5, 0.9]},
+        {"support": "restricted"},
+        {"figsize": (4, 4)},
+    ],
+)
+def test_dirichlet_plot(kwargs):
+    a_dist = pz.Dirichlet([2, 1, 2])
+    a_dist.plot_pdf(**kwargs)
+    kwargs.pop("marginals", None)
+    a_dist.plot_cdf(**kwargs)
+    kwargs.pop("support", None)
+    a_dist.plot_ppf(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"marginals": True},
+        {"pointinterval": True},
+        {"pointinterval": True, "levels": [0.1, 0.9]},
+        {"pointinterval": True, "interval": "eti", "levels": [0.9]},
+        {"pointinterval": True, "interval": "quantiles"},
+        {"pointinterval": True, "interval": "quantiles", "levels": [0.1, 0.5, 0.9]},
+        {"support": "restricted"},
+        {"figsize": (4, 4)},
+    ],
+)
+def test_mvnormal_plot(kwargs):
+    a_dist = pz.MvNormal(np.zeros(2), np.eye(2))
+    a_dist.plot_pdf(**kwargs)
+    kwargs.pop("marginals", None)
+    a_dist.plot_cdf(**kwargs)
+    kwargs.pop("support", None)
+    a_dist.plot_ppf(**kwargs)


### PR DESCRIPTION
This adds general support for Multivariate variables and implements Dirichlet and Multivariate Normal in particular. Both implementations omit some methods compared to univariate. This is partly because of the differences between these two types of distributions, but also because we should think about which methods of elicitation we really want to implement for Multivariate distributions and work from there. One big missing method is `plot_interactive`, this should be added in the following PR:

- [x] Code style is correct (follows pylint and black guidelines)
- [x] Includes new or updated tests to cover the new feature
- [x] New features are properly documented (with an example if appropriate)
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
