### PR TITLE
bambi parser

### DIFF
--- a/preliz/internal/parser.py
+++ b/preliz/internal/parser.py
@@ -111,7 +111,6 @@ def from_bambi(fmodel, draws):
 
         # Find the variables after the return statement
         return_variables = match_return_variables(original_source)
-        print(return_variables)
 
         if return_variables:
             # Build the new source code

--- a/preliz/internal/parser.py
+++ b/preliz/internal/parser.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 import re
 from sys import modules
@@ -54,34 +55,110 @@ def parse_arguments(lst, regex):
     return result
 
 
-def get_prior_pp_samples(fmodel, draws, values=None):
+def get_prior_pp_samples(fmodel, variables, draws, engine=None, values=None):
     if values is None:
         values = []
 
-    match = match_return_variables(fmodel)
+    if engine == "preliz":
+        obs_rv = variables[-1]  # only one observed for the moment
+        pp_samples_ = []
+        prior_samples_ = {name: [] for name in variables[:-1]}
+        for _ in range(draws):
+            for name, value in zip(variables, fmodel(*values)):
+                if name == obs_rv:
+                    pp_samples_.append(value)
+                else:
+                    prior_samples_[name].append(value)
+
+        pp_samples = np.stack(pp_samples_)
+        prior_samples = {key: np.array(val) for key, val in prior_samples_.items()}
+    elif engine == "bambi":
+        *prior_samples_, pp_samples = fmodel(*values)
+        prior_samples = {name: np.array(val) for name, val in zip(variables[:-1], prior_samples_)}
+
+    return pp_samples, prior_samples
+
+
+def from_preliz(fmodel):
+    source = inspect.getsource(fmodel)
+    variables = match_return_variables(source)
+    # Find the priors we want to change
+    all_dist_str = dist_as_str()
+    matches = match_preliz_dist(all_dist_str, source, "preliz")
+    # Create a dictionary with the priors
+    model = dict_model(matches, variables)
+
+    return variables, model
+
+
+def from_bambi(fmodel, draws):
+    module_name = fmodel.__module__
+    module = importlib.import_module(module_name)
+
+    # Get the source code of the original function
+    original_source = inspect.getsource(fmodel)
+
+    # Define a pattern to find the line where the model is built
+    pattern = re.compile(r"(\s+)([a-zA-Z_]\w*)\s*=\s*.*?Model(.*)")
+
+    # Find the match in the source code
+    match = pattern.search(original_source)
+
     if match:
-        variables = [var.strip() for var in match.group(1).split(",")]
+        # Extract the indentation and variable name
+        indentation = match.group(1)
+        variable_name = match.group(2)
 
-    obs_rv = variables[-1]  # only one observed for the moment
-    pp_samples_ = []
-    prior_samples_ = {name: [] for name in variables[:-1]}
-    for _ in range(draws):
-        for name, value in zip(variables, fmodel(*values)):
-            if name == obs_rv:
-                pp_samples_.append(value)
-            else:
-                prior_samples_[name].append(value)
+        # Find the variables after the return statement
+        return_variables = match_return_variables(original_source)
+        print(return_variables)
 
-    pp_samples = np.stack(pp_samples_)
-    prior_samples = {key: np.array(val) for key, val in prior_samples_.items()}
+        if return_variables:
+            # Build the new source code
+            new_source = original_source.replace(
+                match.group(0),
+                f"{match.group(0)}"
+                f"{indentation}{variable_name}.build()\n"
+                f"{indentation}variables = [{variable_name}.backend.model.named_vars[v] for v in {return_variables}]\n"
+                f'{indentation}{", ".join(return_variables)} = pm.draw(variables, draws={draws})',
+            )
 
-    return pp_samples, prior_samples, obs_rv
+            # Find the priors we want to change
+            all_dist_str = dist_as_str()
+            matches = match_preliz_dist(all_dist_str, new_source, "bambi")
+            # Create a dictionary with the priors
+            model = dict_model(matches, return_variables)
+
+            # Execute the new source code to redefine the function
+            exec(new_source, module.__dict__)
+            modified_fmodel = getattr(module, fmodel.__name__)
+
+        return modified_fmodel, return_variables, model
 
 
-def parse_function_for_ppa(source, obs_rv):
+def match_preliz_dist(all_dist_str, source, engine):
+    if engine == "preliz":
+        regex = rf"(.*?({all_dist_str}).*?)\(([^()]*(?:\([^()]*\)[^()]*)*)\)"
+    if engine == "bambi":
+        regex = rf'(\w+)\s*=\s*(?:\w+\.)?Prior\("({all_dist_str})",\s*((?:\w+=\w+(?:,?\s*)?)*)\s*\)'
+    matches = re.finditer(regex, source)
+    return matches
+
+
+def match_return_variables(source):
+    match = re.search(r"return (\w+(\s*,\s*\w+)*)", source)
+    if match:
+        return [var.strip() for var in match.group(1).split(",")]
+
+
+def dist_as_str():
+    all_distributions = modules["preliz.distributions"].__all__
+    return "|".join(all_distributions)
+
+
+def dict_model(matches, return_variables):
     model = {}
-
-    matches = match_preliz_dist(source)
+    obs_rv = return_variables[-1]
     for match in matches:
         var_name = match.group(0).split("=")[0].strip()
         if var_name != obs_rv:
@@ -89,18 +166,3 @@ def parse_function_for_ppa(source, obs_rv):
             model[var_name] = dist()
 
     return model
-
-
-def match_preliz_dist(source):
-    all_distributions = modules["preliz.distributions"].__all__
-    all_dist_str = "|".join(all_distributions)
-
-    regex = rf"(.*?({all_dist_str}).*?)\(([^()]*(?:\([^()]*\)[^()]*)*)\)"
-    matches = re.finditer(regex, source)
-    return matches
-
-
-def match_return_variables(fmodel):
-    source = inspect.getsource(fmodel)
-    match = re.search(r"return (\w+(\s*,\s*\w+)*)", source)
-    return match

--- a/preliz/predictive/ppa.py
+++ b/preliz/predictive/ppa.py
@@ -149,12 +149,12 @@ class FilterDistribution:  # pylint:disable=too-many-instance-attributes
     def __call__(self):
 
         if self.engine == "preliz":
-            self.variables, self.model = from_preliz(self.fmodel)
+            variables, self.model = from_preliz(self.fmodel)
         elif self.engine == "bambi":
-            self.fmodel, self.variables, self.model = from_bambi(self.fmodel, self.draws)
+            self.fmodel, variables, self.model = from_bambi(self.fmodel, self.draws)
 
         self.pp_samples, self.prior_samples = get_prior_pp_samples(
-            self.fmodel, self.variables, self.draws, self.engine
+            self.fmodel, variables, self.draws, self.engine
         )
 
         if self.target is not None:

--- a/preliz/predictive/ppa.py
+++ b/preliz/predictive/ppa.py
@@ -17,7 +17,7 @@ from ..internal.plot_helper import (
     plot_pp_samples,
     plot_pp_mean,
 )
-from ..internal.parser import inspect_source, parse_function_for_ppa, get_prior_pp_samples
+from ..internal.parser import get_prior_pp_samples, from_preliz, from_bambi
 from ..internal.predictive_helper import back_fitting, select_prior_samples
 from ..distributions.continuous import Normal
 from ..distributions.distributions import Distribution
@@ -25,7 +25,9 @@ from ..distributions.distributions import Distribution
 _log = logging.getLogger("preliz")
 
 
-def ppa(fmodel, draws=2000, references=0, boundaries=(-np.inf, np.inf), target=None):
+def ppa(
+    fmodel, draws=2000, references=0, boundaries=(-np.inf, np.inf), target=None, engine="preliz"
+):
     """
     Prior predictive check assistant.
 
@@ -46,6 +48,8 @@ def ppa(fmodel, draws=2000, references=0, boundaries=(-np.inf, np.inf), target=N
         Target distribution. The first shown distributions will be selected to be as close
         as possible to `target`. Available options are, a PreliZ distribution or a 2-tuple with
         the first element representing the mean and the second the standard deviation.
+    engine : str
+        Library used to define the model. Either `preliz` or `bambi`. Defaults to `preliz`
     """
     check_inside_notebook(need_widget=True)
 
@@ -54,7 +58,7 @@ def ppa(fmodel, draws=2000, references=0, boundaries=(-np.inf, np.inf), target=N
     if isinstance(references, (float, int)):
         references = [references]
 
-    filter_dists = FilterDistribution(fmodel, draws, references, boundaries, target)
+    filter_dists = FilterDistribution(fmodel, draws, references, boundaries, target, engine)
     filter_dists()
 
     output = widgets.Output()
@@ -117,19 +121,19 @@ def ppa(fmodel, draws=2000, references=0, boundaries=(-np.inf, np.inf), target=N
 
 
 class FilterDistribution:  # pylint:disable=too-many-instance-attributes
-    def __init__(self, fmodel, draws, references, boundaries, target):
+    def __init__(self, fmodel, draws, references, boundaries, target, engine):
         self.fmodel = fmodel
         self.source = ""  # string representation of the model
         self.draws = draws
         self.references = references
         self.boundaries = boundaries
         self.target = target
+        self.engine = engine
         self.pp_samples = None  # prior predictive samples
         self.prior_samples = None  # prior samples used for backfitting
         self.display_pp_idxs = None  # indices of the pp_samples to be displayed
         self.pp_octiles = None  # octiles computed from pp_samples
         self.kdt = None  # KDTree used to find similar distributions
-        self.obs_rv = None  # name of the observed random variable
         self.model = None  # parsed model used for backfitting
         self.clicked = []  # axes clicked by the user
         self.choices = []  # indices of the pp_samples selected by the user and not yet used to
@@ -144,11 +148,14 @@ class FilterDistribution:  # pylint:disable=too-many-instance-attributes
 
     def __call__(self):
 
-        self.pp_samples, self.prior_samples, self.obs_rv = get_prior_pp_samples(
-            self.fmodel, self.draws
+        if self.engine == "preliz":
+            self.variables, self.model = from_preliz(self.fmodel)
+        elif self.engine == "bambi":
+            self.fmodel, self.variables, self.model = from_bambi(self.fmodel, self.draws)
+
+        self.pp_samples, self.prior_samples = get_prior_pp_samples(
+            self.fmodel, self.variables, self.draws, self.engine
         )
-        self.source, _ = inspect_source(self.fmodel)
-        self.model = parse_function_for_ppa(self.source, self.obs_rv)
 
         if self.target is not None:
             self.add_target_dist()


### PR DESCRIPTION
This allows the use of Bambi models for `ppa` and `predictive_finder`. I only tested the code with a couple of simple models.


```python
def a_bambi_model(a0=2, a1=1, b0=2, b1=1):
    x = bmb.Prior("Normal", mu=a0, sigma=a1)
    Intercept = bmb.Prior("Normal", mu=b0, sigma=b1)
    priors = {"x": x, "Intercept": Intercept}

    model = bmb.Model('y ~ x', data, priors=priors)
    
    return Intercept, x, y

target = pz.Normal(2, sigma=3)
pz.predictive_finder(a_bambi_model, target, draws=100, steps=1, engine="bambi")
```

![Figure 1](https://github.com/arviz-devs/preliz/assets/1338958/7fb8c311-c630-4638-b0cf-3dab5356aedb)
