### PR TITLE
Add checkboxes to control distributions in roulette

### DIFF
--- a/preliz/unidimensional/roulette.py
+++ b/preliz/unidimensional/roulette.py
@@ -50,8 +50,18 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
 
     check_inside_notebook(need_widget=True)
 
-    (w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions, w_checkbox_cont,
-     w_checkbox_disc, w_checkbox_none) = get_widgets(
+    (
+        w_x_min,
+        w_x_max,
+        w_ncols,
+        w_nrows,
+        w_extra,
+        w_repr,
+        w_distributions,
+        w_checkbox_cont,
+        w_checkbox_disc,
+        w_checkbox_none,
+    ) = get_widgets(
         x_min,
         x_max,
         nrows,
@@ -76,10 +86,10 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
         grid = Rectangles(fig, coll, nrows, ncols, ax_grid)
 
         def handle_checkbox_change(_):
-            handle_checkbox_widget(w_distributions,
-                                   w_checkbox_cont,
-                                   w_checkbox_disc,
-                                   w_checkbox_none)
+            dist_names = handle_checkbox_widget(
+                w_distributions.options, w_checkbox_cont, w_checkbox_disc, w_checkbox_none
+            )
+            w_distributions.value = dist_names
 
         w_checkbox_none.observe(handle_checkbox_change)
         w_checkbox_cont.observe(handle_checkbox_change)
@@ -142,7 +152,16 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
 
     controls = widgets.VBox([w_x_min, w_x_max, w_nrows, w_ncols, w_extra])
     control_distribution = widgets.VBox([w_checkbox_cont, w_checkbox_disc, w_checkbox_none])
-    display(widgets.HBox([controls, w_repr, w_distributions, control_distribution]))  # pylint:disable=undefined-variable
+    display(  # pylint:disable=undefined-variable
+        widgets.HBox(
+            [
+                controls,
+                w_repr,
+                w_distributions,
+                control_distribution,
+            ]
+        )
+    )
 
 
 def create_figure(figsize):
@@ -305,22 +324,23 @@ def reset_dist_panel(x_min, x_max, ax, yticks):
     ax.autoscale_view()
 
 
-def handle_checkbox_widget(w_distributions, w_checkbox_cont, w_checkbox_disc, w_checkbox_none):
+def handle_checkbox_widget(options, w_checkbox_cont, w_checkbox_disc, w_checkbox_none):
     if w_checkbox_none.value:
-        w_distributions.value = []
         w_checkbox_disc.value = False
         w_checkbox_cont.value = False
-        return None
+        return []
     all_cls = []
     if w_checkbox_cont.value:
-        all_cont_str = [dist for dist in
-                        (cls.__name__ for cls in all_continuous if cls.__name__ in w_distributions.options)]
+        all_cont_str = [  # pylint:disable=unnecessary-comprehension
+            dist for dist in (cls.__name__ for cls in all_continuous if cls.__name__ in options)
+        ]
         all_cls += all_cont_str
     if w_checkbox_disc.value:
-        all_dist_str = [dist for dist in
-                        (cls.__name__ for cls in all_discrete if cls.__name__ in w_distributions.options)]
+        all_dist_str = [  # pylint:disable=unnecessary-comprehension
+            dist for dist in (cls.__name__ for cls in all_discrete if cls.__name__ in options)
+        ]
         all_cls += all_dist_str
-    w_distributions.value = all_cls
+    return all_cls
 
 
 def get_widgets(x_min, x_max, nrows, ncols, dist_names):
@@ -436,5 +456,15 @@ def get_widgets(x_min, x_max, nrows, ncols, dist_names):
         value=False, description="None", disabled=False, indent=False
     )
 
-    return (w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions,
-            w_checkbox_cont, w_checkbox_disc, w_checkbox_none)
+    return (
+        w_x_min,
+        w_x_max,
+        w_ncols,
+        w_nrows,
+        w_extra,
+        w_repr,
+        w_distributions,
+        w_checkbox_cont,
+        w_checkbox_disc,
+        w_checkbox_none,
+    )

--- a/preliz/unidimensional/roulette.py
+++ b/preliz/unidimensional/roulette.py
@@ -12,6 +12,7 @@ except ImportError:
 from ..internal.optimization import fit_to_ecdf, get_distributions
 from ..internal.plot_helper import check_inside_notebook, representations
 from ..internal.distribution_helper import process_extra
+from ..distributions import all_discrete, all_continuous
 
 
 def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=None):
@@ -49,7 +50,8 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
 
     check_inside_notebook(need_widget=True)
 
-    w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions = get_widgets(
+    (w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions, w_checkbox_cont,
+     w_checkbox_disc, w_checkbox_none) = get_widgets(
         x_min,
         x_max,
         nrows,
@@ -72,6 +74,16 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
 
         coll = create_grid(x_min, x_max, nrows, ncols, ax=ax_grid)
         grid = Rectangles(fig, coll, nrows, ncols, ax_grid)
+
+        def handle_checkbox_change(_):
+            handle_checkbox_widget(w_distributions,
+                                   w_checkbox_cont,
+                                   w_checkbox_disc,
+                                   w_checkbox_none)
+
+        w_checkbox_none.observe(handle_checkbox_change)
+        w_checkbox_cont.observe(handle_checkbox_change)
+        w_checkbox_disc.observe(handle_checkbox_change)
 
         def update_grid_(_):
             update_grid(
@@ -129,8 +141,8 @@ def roulette(x_min=0, x_max=10, nrows=10, ncols=11, dist_names=None, figsize=Non
         )
 
     controls = widgets.VBox([w_x_min, w_x_max, w_nrows, w_ncols, w_extra])
-
-    display(widgets.HBox([controls, w_repr, w_distributions]))  # pylint:disable=undefined-variable
+    control_distribution = widgets.VBox([w_checkbox_cont, w_checkbox_disc, w_checkbox_none])
+    display(widgets.HBox([controls, w_repr, w_distributions, control_distribution]))  # pylint:disable=undefined-variable
 
 
 def create_figure(figsize):
@@ -293,6 +305,24 @@ def reset_dist_panel(x_min, x_max, ax, yticks):
     ax.autoscale_view()
 
 
+def handle_checkbox_widget(w_distributions, w_checkbox_cont, w_checkbox_disc, w_checkbox_none):
+    if w_checkbox_none.value:
+        w_distributions.value = []
+        w_checkbox_disc.value = False
+        w_checkbox_cont.value = False
+        return None
+    all_cls = []
+    if w_checkbox_cont.value:
+        all_cont_str = [dist for dist in
+                        (cls.__name__ for cls in all_continuous if cls.__name__ in w_distributions.options)]
+        all_cls += all_cont_str
+    if w_checkbox_disc.value:
+        all_dist_str = [dist for dist in
+                        (cls.__name__ for cls in all_discrete if cls.__name__ in w_distributions.options)]
+        all_cls += all_dist_str
+    w_distributions.value = all_cls
+
+
 def get_widgets(x_min, x_max, nrows, ncols, dist_names):
 
     width_entry_text = widgets.Layout(width="150px")
@@ -396,4 +426,15 @@ def get_widgets(x_min, x_max, nrows, ncols, dist_names):
         layout=width_distribution_text,
     )
 
-    return w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions
+    w_checkbox_cont = widgets.Checkbox(
+        value=False, description="Continuous", disabled=False, indent=False
+    )
+    w_checkbox_disc = widgets.Checkbox(
+        value=False, description="Discrete", disabled=False, indent=False
+    )
+    w_checkbox_none = widgets.Checkbox(
+        value=False, description="None", disabled=False, indent=False
+    )
+
+    return (w_x_min, w_x_max, w_ncols, w_nrows, w_extra, w_repr, w_distributions,
+            w_checkbox_cont, w_checkbox_disc, w_checkbox_none)


### PR DESCRIPTION
Solves #127 
## Description
Added checkboxes to control the roulette function

- Added three checkboxes `Continuous`, `Discrete`, and `None`.
- Added `handle_checkbox_change` as a handler function.

An image
![image](https://github.com/arviz-devs/preliz/assets/77425744/db80cf6e-65b2-4102-9058-d5e8b9219d77)

<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add Poisson distribution".
  Avoid non-descriptive titles such as "Addresses issue #42".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request a broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Code style is correct (follows pylint and black guidelines)
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Widget states have been properly saved (only for notebooks with widgets) [see](https://github.com/arviz-devs/preliz/wiki/Save-widgets-state) for details.

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/preliz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/preliz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
