### PR TITLE
Add ppe method for predictive elicitation (experimental)

### DIFF
--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -228,7 +228,7 @@ def optimize_beta_mode(lower, upper, tau_not, mode, dist, mass, prob):
             tau_not += 0.5 * tau_not
 
 
-def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info):
+def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info, dist):
     for _ in range(400):
         # can we sample systematically from these and less random?
         # This should be more flexible and allow other targets than just
@@ -239,13 +239,12 @@ def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var
             initial_guess,
             tol=0.001,
             method="SLSQP",
-            args=(obs, var_info),
+            args=(obs, var_info, dist),
             bounds=bounds,
         )
 
         optimal_params = result.x
         initial_guess = optimal_params
-        print(optimal_params)
 
         for key, param in zip(prior.keys(), optimal_params):
             prior[key].append(param)

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -229,7 +229,7 @@ def optimize_beta_mode(lower, upper, tau_not, mode, dist, mass, prob):
 
 
 def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info):
-    for _ in range(1000):
+    for _ in range(400):
         # can we sample systematically from these and less random?
         # This should be more flexible and allow other targets than just
         # a preliz distribution
@@ -245,6 +245,7 @@ def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var
 
         optimal_params = result.x
         initial_guess = optimal_params
+        print(optimal_params)
 
         for key, param in zip(prior.keys(), optimal_params):
             prior[key].append(param)

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -228,7 +228,7 @@ def optimize_beta_mode(lower, upper, tau_not, mode, dist, mass, prob):
             tau_not += 0.5 * tau_not
 
 
-def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info, dist):
+def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info, p_model):
     for _ in range(400):
         # can we sample systematically from these and less random?
         # This should be more flexible and allow other targets than just
@@ -239,7 +239,7 @@ def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var
             initial_guess,
             tol=0.001,
             method="SLSQP",
-            args=(obs, var_info, dist),
+            args=(obs, var_info, p_model),
             bounds=bounds,
         )
 

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -228,6 +228,34 @@ def optimize_beta_mode(lower, upper, tau_not, mode, dist, mass, prob):
             tau_not += 0.5 * tau_not
 
 
+def optimize_pymc_model(fmodel, target, draws, prior, initial_guess, bounds, var_info):
+    for _ in range(1000):
+        # can we sample systematically from these and less random?
+        # This should be more flexible and allow other targets than just
+        # a preliz distribution
+        obs = target.rvs(draws)
+        result = minimize(
+            fmodel,
+            initial_guess,
+            tol=0.001,
+            method="SLSQP",
+            args=(obs, var_info),
+            bounds=bounds,
+        )
+
+        optimal_params = result.x
+        initial_guess = optimal_params
+
+        for key, param in zip(prior.keys(), optimal_params):
+            prior[key].append(param)
+
+    # convert to numpy arrays
+    for key, value in prior.items():
+        prior[key] = np.array(value)
+
+    return prior
+
+
 def relative_error(dist, lower, upper, required_mass):
     if dist.kind == "discrete":
         lower -= 1

--- a/preliz/ppls/pymc.py
+++ b/preliz/ppls/pymc.py
@@ -180,7 +180,10 @@ def reshape_params(model, var_info, p_model, params):
         if idxs:
             dist = p_model[var.name]
             dist._parametrization(*params[idxs])
-            value.append(np.repeat(dist.mean(), new_size))
+            if new_size > 1:
+                value.append(np.repeat(dist.mean(), new_size))
+            else:
+                value.append(dist.mean())
             size += new_size
         else:
             var_samples = params[size : size + new_size]

--- a/preliz/ppls/pymc.py
+++ b/preliz/ppls/pymc.py
@@ -1,0 +1,126 @@
+from sys import modules
+
+import numpy as np
+
+
+from pytensor.tensor import vector as pt_vector
+from pymc import logp, compile_pymc
+from pymc.util import is_transformed_name, get_untransformed_name
+
+from ..internal.optimization import get_distributions
+
+
+def backfitting(prior, p_model, var_info2):  #### we already have a function with this name
+    new_priors = {}
+    for key, size_inf in var_info2.items():
+        size = size_inf[1]
+        if size > 1:
+            params = []
+            for i in range(size):
+                value = prior[f"{key}__{i}"]
+                dist = p_model[key]
+                dist._fit_mle(value)
+                params.append(dist.params)
+            dist._parametrization(*[np.array(x) for x in zip(*params)])
+        else:
+            value = prior[key]
+            dist = p_model[key]
+            dist._fit_mle(value)
+
+        new_priors[key] = dist
+
+    return new_priors
+
+
+def compile_logp(model):
+    value = pt_vector("value")
+    rv_logp = logp(*model.observed_RVs, value)
+    rv_logp_fn = compile_pymc([*model.free_RVs, value], rv_logp)
+
+    def fmodel(params, obs, var_info):
+        params = reshape_params(model, var_info, params)
+        y = -rv_logp_fn(*params, obs).sum()
+        return y
+
+    return fmodel
+
+
+def get_pymc_to_preliz():
+    """
+    Generate dictionary mapping pymc to preliz distributions
+    """
+    all_distributions = modules["preliz.distributions"].__all__
+    pymc_to_preliz = dict(
+        zip([dist.lower() for dist in all_distributions], get_distributions(all_distributions))
+    )
+    return pymc_to_preliz
+
+
+def get_guess(model):
+    init = []
+    for key, value in model.initial_point().items():
+        if is_transformed_name(key):
+            un_name = get_untransformed_name(key)
+            value = model.rvs_to_transforms[model.named_vars[un_name]].backward(value).eval()
+
+        init.append(value)
+
+    return np.concatenate([np.atleast_1d(arr) for arr in init]).flatten()
+
+
+def get_model_information(model):
+    bounds = []
+    prior = {}
+    p_model = {}
+    var_info = {}
+    var_info2 = {}
+    pymc_to_preliz = get_pymc_to_preliz()
+    rvs_to_values = model.rvs_to_values
+    for r_v in model.free_RVs:
+        name = r_v.owner.op.name
+        dist = pymc_to_preliz[name]
+        r_v_eval = r_v.eval()
+        size = r_v_eval.size
+        shape = r_v_eval.shape
+        if size > 1:
+            for i in range(size):
+                bounds.append(dist.support)
+                prior[f"{r_v.name}__{i}"] = []
+        else:
+            bounds.append(dist.support)
+            prior[r_v.name] = []
+
+        var_info[rvs_to_values[r_v].name] = (shape, size)
+        var_info2[r_v.name] = (shape, size)
+
+        p_model[r_v.name] = dist
+
+    draws = model.observed_RVs[0].eval().size
+
+    return bounds, prior, p_model, var_info, var_info2, draws
+
+
+def write_pymc_string(new_priors, var_info):
+    header = "with pm.Model() as model:\n"
+
+    for key, value in new_priors.items():
+        dist_name, dist_params = repr(value).split("(")
+        size = var_info[key][1]
+        if size > 1:
+            dist_params = dist_params.split(")")[0]
+            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}, shape={size})\n'
+        else:
+            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}\n'
+
+    return header
+
+
+def reshape_params(model, var_info, params):
+    size = 0
+    value = []
+    for var in model.value_vars:
+        shape, new_size = var_info[var.name]
+        var_samples = params[size : size + new_size]
+        value.append(var_samples.reshape(shape))
+        size += new_size
+    return value

--- a/preliz/ppls/pymc_io.py
+++ b/preliz/ppls/pymc_io.py
@@ -9,8 +9,8 @@ try:
     from pytensor.tensor import vector, TensorConstant
     from pymc import logp, compile_pymc
     from pymc.util import is_transformed_name, get_untransformed_name
-except ImportError as exc:
-    raise ImportError("You need to have PyMC installed to use this module") from exc
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError("You need to have PyMC installed to use this module") from exc
 
 from preliz.internal.optimization import get_distributions
 

--- a/preliz/ppls/pymc_io.py
+++ b/preliz/ppls/pymc_io.py
@@ -9,8 +9,8 @@ try:
     from pytensor.tensor import vector, TensorConstant
     from pymc import logp, compile_pymc
     from pymc.util import is_transformed_name, get_untransformed_name
-except ModuleNotFoundError as exc:
-    raise ModuleNotFoundError("You need to have PyMC installed to use this module") from exc
+except ModuleNotFoundError:
+    pass
 
 from preliz.internal.optimization import get_distributions
 

--- a/preliz/predictive/__init__.py
+++ b/preliz/predictive/__init__.py
@@ -1,5 +1,6 @@
 from .ppa import ppa
+from .ppe import ppe
 from .predictive_explorer import predictive_explorer
 
 
-__all__ = ["ppa", "predictive_explorer"]
+__all__ = ["ppa", "ppe", "predictive_explorer"]

--- a/preliz/predictive/ppe.py
+++ b/preliz/predictive/ppe.py
@@ -67,9 +67,7 @@ def ppe(model, target):
     # so, even when we are optimizing we obtain a distribution of parameters
     # The parameters of the minimize function are based on what we do in kulprit
     # but we can tweak them to make it more robust and/or faster.
-    dist = Normal(0, 1)
-
-    prior = optimize_pymc_model(fmodel, target, draws, prior, guess, bounds, var_info, dist)
+    prior = optimize_pymc_model(fmodel, target, draws, prior, guess, bounds, var_info, p_model)
     # we fit the distributions of parameters into the original families
     # in the future we could try to fit to other families
     # and return two model one with the original families and

--- a/preliz/predictive/ppe.py
+++ b/preliz/predictive/ppe.py
@@ -1,13 +1,15 @@
+"""Projective predictive elicitation."""
+
 import logging
 
-from ..ppls.pymc import (
+from preliz.internal.optimization import optimize_pymc_model
+from preliz.ppls.pymc_io import (
     get_model_information,
     get_guess,
     compile_logp,
     backfitting,
     write_pymc_string,
 )
-from ..internal.optimization import optimize_pymc_model
 
 
 _log = logging.getLogger("preliz")

--- a/preliz/predictive/ppe.py
+++ b/preliz/predictive/ppe.py
@@ -1,0 +1,170 @@
+from sys import modules
+
+import numpy as np
+from scipy.optimize import minimize
+
+
+from pytensor.tensor import vector as pt_vector
+from pymc import logp, compile_pymc
+from pymc.util import is_transformed_name, get_untransformed_name
+
+from ..internal.optimization import get_distributions
+
+
+def ppe(model, target):
+    """
+    Projective Predictive Elicitation
+    """
+    bounds, prior, p_model, var_info, var_info2 = get_model_information(model)
+    guess = get_guess(model)
+    fmodel = compile_logp(model)
+
+    prior = optimize_pymc_model(fmodel, target, prior, guess, bounds, var_info)
+    new_priors = backfitting(prior, p_model, var_info2)
+
+    return prior, write_pymc_string(new_priors, var_info2)
+
+
+def backfitting(prior, p_model, var_info2):  #### we already have a function with this name
+    new_priors = {}
+    for key, size_inf in var_info2.items():
+        size = size_inf[1]
+        if size > 1:
+            params = []
+            for i in range(size):
+                value = prior[f"{key}__{i}"]
+                dist = p_model[key]
+                dist._fit_mle(value)
+                params.append(dist.params)
+            dist._parametrization(*[np.array(x) for x in zip(*params)])
+        else:
+            value = prior[key]
+            dist = p_model[key]
+            dist._fit_mle(value)
+
+        new_priors[key] = dist
+
+    return new_priors
+
+
+## some pymc to preliz module???
+def compile_logp(model):
+    value = pt_vector("value")
+    rv_logp = logp(*model.observed_RVs, value)
+    rv_logp_fn = compile_pymc([*model.free_RVs, value], rv_logp)
+
+    def fmodel(params, obs, var_info):
+        params = reshape_params(model, var_info, params)
+        y = -rv_logp_fn(*params, obs).sum()
+        return y
+
+    return fmodel
+
+
+def get_pymc_to_preliz():
+    """
+    Generate dictionary mapping pymc to preliz distributions
+    """
+    all_distributions = modules["preliz.distributions"].__all__
+    pymc_to_preliz = dict(
+        zip([dist.lower() for dist in all_distributions], get_distributions(all_distributions))
+    )
+    return pymc_to_preliz
+
+
+def get_guess(model):
+    init = []
+    for key, value in model.initial_point().items():
+        if is_transformed_name(key):
+            un_name = get_untransformed_name(key)
+            value = model.rvs_to_transforms[model.named_vars[un_name]].backward(value).eval()
+
+        init.append(value)
+
+    return np.concatenate([np.atleast_1d(arr) for arr in init]).flatten()
+
+
+def get_model_information(model):
+    bounds = []
+    prior = {}
+    p_model = {}
+    var_info = {}
+    var_info2 = {}
+    pymc_to_preliz = get_pymc_to_preliz()
+    rvs_to_values = model.rvs_to_values
+    for r_v in model.free_RVs:
+        name = r_v.owner.op.name
+        dist = pymc_to_preliz[name]
+        r_v_eval = r_v.eval()
+        size = r_v_eval.size
+        shape = r_v_eval.shape
+        if size > 1:
+            for i in range(size):
+                bounds.append(dist.support)
+                prior[f"{r_v.name}__{i}"] = []
+        else:
+            bounds.append(dist.support)
+            prior[r_v.name] = []
+
+        var_info[rvs_to_values[r_v].name] = (shape, size)
+        var_info2[r_v.name] = (shape, size)
+
+        p_model[r_v.name] = dist
+
+    return bounds, prior, p_model, var_info, var_info2
+
+
+def write_pymc_string(new_priors, var_info):
+    header = "with pm.Model() as model:\n"
+
+    for key, value in new_priors.items():
+        dist_name, dist_params = repr(value).split("(")
+        size = var_info[key][1]
+        if size > 1:
+            dist_params = dist_params.split(")")[0]
+            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}, shape={size})\n'
+        else:
+            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}\n'
+
+    return header
+
+
+def reshape_params(model, var_info, params):
+    size = 0
+    value = []
+    for var in model.value_vars:
+        shape, new_size = var_info[var.name]
+        var_samples = params[size : size + new_size]
+        # Round discrete variable samples. The rounded values were the ones
+        # actually used in the logp evaluations (see logp_forw)
+        # if var.dtype in discrete_types:
+        #    var_samples = np.round(var_samples).astype(var.dtype)
+        value.append(np.atleast_1d(var_samples).reshape(shape))
+        size += new_size
+    return value
+
+
+### optimization
+def optimize_pymc_model(fmodel, target, prior, initial_guess, bounds, var_info):
+    for _ in range(1000):
+        obs = target.rvs(120)  # can we sample systematically from these and less random?
+        result = minimize(
+            fmodel,
+            initial_guess,
+            tol=0.001,
+            method="SLSQP",
+            args=(obs, var_info),
+            bounds=bounds,
+        )
+
+        optimal_params = result.x
+        initial_guess = optimal_params
+
+        for key, param in zip(prior.keys(), optimal_params):
+            prior[key].append(param)
+
+    # convert to numpy arrays
+    for key, value in prior.items():
+        prior[key] = np.array(value)
+
+    return prior

--- a/preliz/predictive/ppe.py
+++ b/preliz/predictive/ppe.py
@@ -1,170 +1,22 @@
-from sys import modules
-
-import numpy as np
-from scipy.optimize import minimize
-
-
-from pytensor.tensor import vector as pt_vector
-from pymc import logp, compile_pymc
-from pymc.util import is_transformed_name, get_untransformed_name
-
-from ..internal.optimization import get_distributions
+from ..ppls.pymc import (
+    get_model_information,
+    get_guess,
+    compile_logp,
+    backfitting,
+    write_pymc_string,
+)
+from ..internal.optimization import optimize_pymc_model
 
 
 def ppe(model, target):
     """
     Projective Predictive Elicitation
     """
-    bounds, prior, p_model, var_info, var_info2 = get_model_information(model)
+    bounds, prior, p_model, var_info, var_info2, draws = get_model_information(model)
     guess = get_guess(model)
     fmodel = compile_logp(model)
 
-    prior = optimize_pymc_model(fmodel, target, prior, guess, bounds, var_info)
+    prior = optimize_pymc_model(fmodel, target, draws, prior, guess, bounds, var_info)
     new_priors = backfitting(prior, p_model, var_info2)
 
     return prior, write_pymc_string(new_priors, var_info2)
-
-
-def backfitting(prior, p_model, var_info2):  #### we already have a function with this name
-    new_priors = {}
-    for key, size_inf in var_info2.items():
-        size = size_inf[1]
-        if size > 1:
-            params = []
-            for i in range(size):
-                value = prior[f"{key}__{i}"]
-                dist = p_model[key]
-                dist._fit_mle(value)
-                params.append(dist.params)
-            dist._parametrization(*[np.array(x) for x in zip(*params)])
-        else:
-            value = prior[key]
-            dist = p_model[key]
-            dist._fit_mle(value)
-
-        new_priors[key] = dist
-
-    return new_priors
-
-
-## some pymc to preliz module???
-def compile_logp(model):
-    value = pt_vector("value")
-    rv_logp = logp(*model.observed_RVs, value)
-    rv_logp_fn = compile_pymc([*model.free_RVs, value], rv_logp)
-
-    def fmodel(params, obs, var_info):
-        params = reshape_params(model, var_info, params)
-        y = -rv_logp_fn(*params, obs).sum()
-        return y
-
-    return fmodel
-
-
-def get_pymc_to_preliz():
-    """
-    Generate dictionary mapping pymc to preliz distributions
-    """
-    all_distributions = modules["preliz.distributions"].__all__
-    pymc_to_preliz = dict(
-        zip([dist.lower() for dist in all_distributions], get_distributions(all_distributions))
-    )
-    return pymc_to_preliz
-
-
-def get_guess(model):
-    init = []
-    for key, value in model.initial_point().items():
-        if is_transformed_name(key):
-            un_name = get_untransformed_name(key)
-            value = model.rvs_to_transforms[model.named_vars[un_name]].backward(value).eval()
-
-        init.append(value)
-
-    return np.concatenate([np.atleast_1d(arr) for arr in init]).flatten()
-
-
-def get_model_information(model):
-    bounds = []
-    prior = {}
-    p_model = {}
-    var_info = {}
-    var_info2 = {}
-    pymc_to_preliz = get_pymc_to_preliz()
-    rvs_to_values = model.rvs_to_values
-    for r_v in model.free_RVs:
-        name = r_v.owner.op.name
-        dist = pymc_to_preliz[name]
-        r_v_eval = r_v.eval()
-        size = r_v_eval.size
-        shape = r_v_eval.shape
-        if size > 1:
-            for i in range(size):
-                bounds.append(dist.support)
-                prior[f"{r_v.name}__{i}"] = []
-        else:
-            bounds.append(dist.support)
-            prior[r_v.name] = []
-
-        var_info[rvs_to_values[r_v].name] = (shape, size)
-        var_info2[r_v.name] = (shape, size)
-
-        p_model[r_v.name] = dist
-
-    return bounds, prior, p_model, var_info, var_info2
-
-
-def write_pymc_string(new_priors, var_info):
-    header = "with pm.Model() as model:\n"
-
-    for key, value in new_priors.items():
-        dist_name, dist_params = repr(value).split("(")
-        size = var_info[key][1]
-        if size > 1:
-            dist_params = dist_params.split(")")[0]
-            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}, shape={size})\n'
-        else:
-            header += f'{key:>4} = pm.{dist_name}("{key}", {dist_params}\n'
-
-    return header
-
-
-def reshape_params(model, var_info, params):
-    size = 0
-    value = []
-    for var in model.value_vars:
-        shape, new_size = var_info[var.name]
-        var_samples = params[size : size + new_size]
-        # Round discrete variable samples. The rounded values were the ones
-        # actually used in the logp evaluations (see logp_forw)
-        # if var.dtype in discrete_types:
-        #    var_samples = np.round(var_samples).astype(var.dtype)
-        value.append(np.atleast_1d(var_samples).reshape(shape))
-        size += new_size
-    return value
-
-
-### optimization
-def optimize_pymc_model(fmodel, target, prior, initial_guess, bounds, var_info):
-    for _ in range(1000):
-        obs = target.rvs(120)  # can we sample systematically from these and less random?
-        result = minimize(
-            fmodel,
-            initial_guess,
-            tol=0.001,
-            method="SLSQP",
-            args=(obs, var_info),
-            bounds=bounds,
-        )
-
-        optimal_params = result.x
-        initial_guess = optimal_params
-
-        for key, param in zip(prior.keys(), optimal_params):
-            prior[key].append(param)
-
-    # convert to numpy arrays
-    for key, value in prior.items():
-        prior[key] = np.array(value)
-
-    return prior

--- a/preliz/predictive/ppe.py
+++ b/preliz/predictive/ppe.py
@@ -1,3 +1,5 @@
+import logging
+
 from ..ppls.pymc import (
     get_model_information,
     get_guess,
@@ -7,16 +9,66 @@ from ..ppls.pymc import (
 )
 from ..internal.optimization import optimize_pymc_model
 
+_log = logging.getLogger("preliz")
+
 
 def ppe(model, target):
     """
-    Projective Predictive Elicitation
+    Projective Predictive Elicitation.
+
+    This is an experimental method under development, use with caution.
+    Most likely thing will break.
+
+    Parameters
+    ----------
+    model : a probabilistic model
+        Currently it only works with PyMC model. More PPls coming soon.
+    target : a Preliz distribution
+        This represent the prior predictive distribution **previously** elicited from the user,
+        possibly using other Preliz's methods to obtain this distribution, such as maxent,
+        roulette, quartile, etc.
+        This should represent the domain-knowledge of the user and not any observed dataset.
+        Currently only works with a Preliz distributions. In the future we should support mixture of
+        distributions (mixture of "experts"), and maybe other options.
+
+    Returns
+    -------
+    prior : a dictionary
+        A dictionary with the "prior" distribution of the model.
+        This is actually the "projected posterior". But we call it "prior" because it is the
+        prior from the perspective of the user.
+    pymc_string : a string
+        This is the PyMC model string with the new priors. This is what the user will want to use.
+        we obtain this by taking the "prior" (the first  output) and fit it to the model's prior families
+        using MLE.
     """
+
+    _log.info(""""This is an experimental method under development, use with caution.""")
+
+    # We collect some useful information from the model
+    # probably there is a lot to improve here, to make it more robust, clean and
+    # flexible
     bounds, prior, p_model, var_info, var_info2, draws = get_model_information(model)
+    # initial guess for optimization routine. This is taken from model.initial_point
+    # inside the optimziation routine this is updated to be estimate from the previous
+    # step.
     guess = get_guess(model)
+    # The log_likelihood function. This is the function we want to optimize
+    # We can condition it on parameters or data
+    # This will not work for prior that depends on other prior,
+    # the function is "insensitive" to the top prior.
     fmodel = compile_logp(model)
 
+    # we optimize the model to fit the target distribution
+    # we actually fit to 500 samples from the target
+    # so, even when we are optimizing we obtain a distribution of parameters
+    # The parameters of the minimize function are based on what we do in kulprit
+    # but we can tweak them to make it more robust and/or faster.
     prior = optimize_pymc_model(fmodel, target, draws, prior, guess, bounds, var_info)
+    # we fit the distributions of parameters into the original families
+    # in the future we could try to fit to other families
+    # and return two model one with the original families and
+    # one with suggested new famlies.
     new_priors = backfitting(prior, p_model, var_info2)
 
     return prior, write_pymc_string(new_priors, var_info2)


### PR DESCRIPTION
Early draft for a predictive elicitation method. I only tested on a couple of simple models, I already know it will fail for others, this is just a proof of concept.

The main idea is that the user provides a model (currently only PyMC, adding Bambi should be easy) and a "target distribution". This distribution is not any particular data set, but the "not yet observed data". The author of Understanding Advanced Statistical Methods calls this "DATA"  as opposed to "data" (the dataset I want to "fit"). So if my model is about the height of adults in San Luis (from which I got a sample, i.e. my data). I can use my domain knowledge of adult humans (DATA) to elicit the target distribution.

A summary of the algorithm is:
Generate a sample from the target distribution.  
Maximize the model's likelihood to that sample (i.e. we find the parameters for a fixed "observation").
Generate a new sample from the target and repeat.
Collect the optimized values in an array (one per prior parameter in the original model).
Use MLE to fit the optimized values to their corresponding families in the original model. 


This approach is similar to what we do in Kulprit. One difference is that for kulprit the "target" is actually the posterior predictive distribution of a reference model, and we are interested in finding submodels (and their psoteriors) that will induce predictions as close as possible to the predictions from the reference model. Here we don't have a reference model, we instead have a human (or potentially a few humans). The other difference is that for kulrpit the optimized values are an approximation to the posterior that we care, here we need to fit those values to the prior's families in the original model, because we can not use samples as priors in a PyMC (or other PPLs) model.
The other difference is that here we use a slightly different approach to obtain the likelihood function for the optimization routine. If this can be generalized, we can use it in Kulprit too, I think this approach was not available when we discussed Kulprit's design and it could potentially make the code easier to maintain and extend.