### PR TITLE
Add faster Normal implementation

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -24,12 +24,11 @@ This reference provides detailed documentation for user functions in the current
 :mod:`preliz.distributions.continuous`
 ======================================
 
-.. automodule:: preliz.distributions.continuous
-   :members:
-
 .. automodule:: preliz.distributions.normal
    :members:
 
+.. automodule:: preliz.distributions.continuous
+   :members:
 
 :mod:`preliz.distributions.discrete`
 ====================================

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -27,6 +27,9 @@ This reference provides detailed documentation for user functions in the current
 .. automodule:: preliz.distributions.continuous
    :members:
 
+.. automodule:: preliz.distributions.normal
+   :members:
+
 
 :mod:`preliz.distributions.discrete`
 ====================================

--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -16,7 +16,7 @@ from scipy.special import logit, expit  # pylint: disable=no-name-in-module
 from ..internal.optimization import optimize_ml, optimize_moments, optimize_moments_rice
 from ..internal.distribution_helper import garcia_approximation, all_not_none, any_not_none
 from .distributions import Continuous
-from .normal import Normal as Normal
+from .normal import Normal  # pylint: disable=unused-import
 
 eps = np.finfo(float).eps
 

--- a/preliz/distributions/continuous.py
+++ b/preliz/distributions/continuous.py
@@ -16,6 +16,7 @@ from scipy.special import logit, expit  # pylint: disable=no-name-in-module
 from ..internal.optimization import optimize_ml, optimize_moments, optimize_moments_rice
 from ..internal.distribution_helper import garcia_approximation, all_not_none, any_not_none
 from .distributions import Continuous
+from .normal import Normal as Normal
 
 eps = np.finfo(float).eps
 
@@ -1926,106 +1927,6 @@ class Moyal(Continuous):
         sigma = sigma / np.pi * 2**0.5
         mu = mean - sigma * (np.euler_gamma + np.log(2))
         self._update(mu, sigma)
-
-    def _fit_mle(self, sample, **kwargs):
-        mu, sigma = self.dist.fit(sample, **kwargs)
-        self._update(mu, sigma)
-
-
-class Normal(Continuous):
-    r"""
-    Normal distribution.
-
-    The pdf of this distribution is
-
-    .. math::
-
-       f(x \mid \mu, \sigma) =
-           \frac{1}{\sigma \sqrt{2\pi}}
-           \exp\left\{ -\frac{1}{2} \left(\frac{x-\mu}{\sigma}\right)^2 \right\}
-
-    .. plot::
-        :context: close-figs
-
-        import arviz as az
-        from preliz import Normal
-        az.style.use('arviz-white')
-        mus = [0., 0., -2.]
-        sigmas = [1, 0.5, 1]
-        for mu, sigma in zip(mus, sigmas):
-            Normal(mu, sigma).plot_pdf()
-
-    ========  ==========================================
-    Support   :math:`x \in \mathbb{R}`
-    Mean      :math:`\mu`
-    Variance  :math:`\sigma^2`
-    ========  ==========================================
-
-    Normal distribution has 2 alternative parameterizations. In terms of mean and
-    sigma (standard deviation), or mean and tau (precision).
-
-    The link between the 2 alternatives is given by
-
-    .. math::
-
-        \tau = \frac{1}{\sigma^2}
-
-    Parameters
-    ----------
-    mu : float
-        Mean.
-    sigma : float
-        Standard deviation (sigma > 0).
-    tau : float
-        Precision (tau > 0).
-    """
-
-    def __init__(self, mu=None, sigma=None, tau=None):
-        super().__init__()
-        self.dist = copy(stats.norm)
-        self.support = (-np.inf, np.inf)
-        self._parametrization(mu, sigma, tau)
-
-    def _parametrization(self, mu=None, sigma=None, tau=None):
-        if all_not_none(sigma, tau):
-            raise ValueError(
-                "Incompatible parametrization. Either use mu and sigma, or mu and tau."
-            )
-
-        names = ("mu", "sigma")
-        self.params_support = ((-np.inf, np.inf), (eps, np.inf))
-
-        if tau is not None:
-            self.tau = tau
-            sigma = from_precision(tau)
-            names = ("mu", "tau")
-
-        self.mu = mu
-        self.sigma = sigma
-        self.param_names = names
-        if all_not_none(mu, sigma):
-            self._update(mu, sigma)
-
-    def _get_frozen(self):
-        frozen = None
-        if all_not_none(self.params):
-            frozen = self.dist(self.mu, self.sigma)
-        return frozen
-
-    def _update(self, mu, sigma):
-        self.mu = np.float64(mu)
-        self.sigma = np.float64(sigma)
-        self.tau = to_precision(sigma)
-
-        if self.param_names[1] == "sigma":
-            self.params = (self.mu, self.sigma)
-        elif self.param_names[1] == "tau":
-            self.params = (self.mu, self.tau)
-
-        self._update_rv_frozen()
-
-    def _fit_moments(self, mean, sigma):
-        self._update(mean, sigma)
 
     def _fit_mle(self, sample, **kwargs):
         mu, sigma = self.dist.fit(sample, **kwargs)

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -78,10 +78,10 @@ class Distribution:
 
         if valid_scalar_params(self):
             attr = namedtuple(self.__class__.__name__, ["mean", "median", "std", "lower", "upper"])
-            mean = float(f"{self.rv_frozen.mean():{fmt}}")
-            median = float(f"{self.rv_frozen.median():{fmt}}")
-            std = float(f"{self.rv_frozen.std():{fmt}}")
-            eti = self.rv_frozen.interval(mass)
+            mean = float(f"{self.mean():{fmt}}")
+            median = float(f"{self.median():{fmt}}")
+            std = float(f"{self.std():{fmt}}")
+            eti = self.eti(mass)
             lower_tail = float(f"{eti[0]:{fmt}}")
             upper_tail = float(f"{eti[1]:{fmt}}")
             return attr(mean, median, std, lower_tail, upper_tail)
@@ -120,6 +120,66 @@ class Distribution:
         """
         return self.rv_frozen.ppf(q, *args, **kwds)
 
+    def mean(self):
+        """Mean of the distribution."""
+        return self.rv_frozen.mean()
+
+    def median(self):
+        """Median of the distribution."""
+        return self.rv_frozen.median()
+
+    def std(self):
+        """Standard deviation of the distribution."""
+        return self.rv_frozen.std()
+
+    def var(self):
+        """Variance of the distribution."""
+        return self.rv_frozen.var()
+
+    def skewness(self):
+        """Skewness of the distribution."""
+        return self.stats(moment="s")
+
+    def kurtois(self):
+        """Kurtosis of the distribution"""
+        return self.stats(moments="k")
+
+    def moments(self, types="mvsk"):
+        """
+        Compute moments of the distribution.
+
+        It can also return the standard deviation
+
+        Parameters
+        ----------
+        types : str
+            The type of moments to compute. Default is 'mvsk'
+            where 'm' = mean, 'v' = variance, 's' = skewness, and 'k' = kurtosis.
+            Valid combinations are any subset of 'mvsk'.
+        """
+        if self.rv_frozen is None:
+            moments = []
+            for m_t in types:
+                if m_t not in "mdvsk":
+                    raise ValueError(
+                        "The input string should only contain the letters 'm', 'd', 'v', 's', or 'k'."
+                    )
+                else:
+                    if m_t == "m":
+                        moments.append(self.mean())
+                    elif m_t == "d":
+                        moments.append(self.std())
+                    elif m_t == "v":
+                        moments.append(self.var())
+                    elif m_t == "s":
+                        moments.append(self.skewness())
+                    elif m_t == "k":
+                        moments.append(self.kurtosis())
+        else:
+            moments = self.rv_frozen.stats(moments=types)
+
+        return moments
+
     def eti(self, mass=0.94, fmt=".2f"):
         """Equal-tailed interval containing `mass`.
 
@@ -137,9 +197,13 @@ class Distribution:
             raise ValueError("Invalid format string.")
 
         if valid_scalar_params(self):
-            eti = self.rv_frozen.interval(mass)
-            lower_tail = float(f"{eti[0]:{fmt}}")
-            upper_tail = float(f"{eti[1]:{fmt}}")
+            if self.rv_frozen is None:
+                z = [(1 - mass) / 2, 1 - (1 - mass) / 2]
+                eti_b = self.ppf(z)
+            else:
+                eti_b = self.rv_frozen.interval(mass)
+            lower_tail = float(f"{eti_b[0]:{fmt}}")
+            upper_tail = float(f"{eti_b[1]:{fmt}}")
             return (lower_tail, upper_tail)
         else:
             return None
@@ -563,6 +627,16 @@ class Continuous(Distribution):
         """
         return self.rv_frozen.pdf(x, *args, **kwds)
 
+    def logpdf(self, x, *args, **kwds):
+        """Probability mass function at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Values on which to evaluate the pdf
+        """
+        return self.rv_frozen.logpdf(x, *args, **kwds)
+
 
 class Discrete(Distribution):
     """Base class for discrete distributions."""
@@ -588,3 +662,13 @@ class Discrete(Distribution):
             Values on which to evaluate the pdf
         """
         return self.rv_frozen.pmf(x, *args, **kwds)
+
+    def logpdf(self, x, *args, **kwds):
+        """Probability mass function at x.
+
+        Parameters
+        ----------
+        x : array_like
+            Values on which to evaluate the pdf
+        """
+        return self.rv_frozen.logpmf(x, *args, **kwds)

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -162,19 +162,19 @@ class Distribution:
             for m_t in types:
                 if m_t not in "mdvsk":
                     raise ValueError(
-                        "The input string should only contain the letters 'm', 'd', 'v', 's', or 'k'."
+                        "The input string should only contain the letters "
+                        "'m', 'd', 'v', 's', or 'k'."
                     )
-                else:
-                    if m_t == "m":
-                        moments.append(self.mean())
-                    elif m_t == "d":
-                        moments.append(self.std())
-                    elif m_t == "v":
-                        moments.append(self.var())
-                    elif m_t == "s":
-                        moments.append(self.skewness())
-                    elif m_t == "k":
-                        moments.append(self.kurtosis())
+                if m_t == "m":
+                    moments.append(self.mean())
+                elif m_t == "d":
+                    moments.append(self.std())
+                elif m_t == "v":
+                    moments.append(self.var())
+                elif m_t == "s":
+                    moments.append(self.skewness())
+                elif m_t == "k":
+                    moments.append(self.kurtosis())
         else:
             moments = self.rv_frozen.stats(moments=types)
 
@@ -198,8 +198,7 @@ class Distribution:
 
         if valid_scalar_params(self):
             if self.rv_frozen is None:
-                z = [(1 - mass) / 2, 1 - (1 - mass) / 2]
-                eti_b = self.ppf(z)
+                eti_b = self.ppf([(1 - mass) / 2, 1 - (1 - mass) / 2])
             else:
                 eti_b = self.rv_frozen.interval(mass)
             lower_tail = float(f"{eti_b[0]:{fmt}}")

--- a/preliz/distributions/normal.py
+++ b/preliz/distributions/normal.py
@@ -1,0 +1,183 @@
+import numba as nb
+import numpy as np
+from scipy.special import erf, erfinv
+
+from .distributions import Continuous
+from ..internal.distribution_helper import eps, to_precision, from_precision, all_not_none
+
+
+class Normal(Continuous):
+    r"""
+    Normal distribution.
+
+    The pdf of this distribution is
+
+    .. math::
+
+       f(x \mid \mu, \sigma) =
+           \frac{1}{\sigma \sqrt{2\pi}}
+           \exp\left\{ -\frac{1}{2} \left(\frac{x-\mu}{\sigma}\right)^2 \right\}
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        from preliz import Normal
+        az.style.use('arviz-white')
+        mus = [0., 0., -2.]
+        sigmas = [1, 0.5, 1]
+        for mu, sigma in zip(mus, sigmas):
+            Normal(mu, sigma).plot_pdf()
+
+    ========  ==========================================
+    Support   :math:`x \in \mathbb{R}`
+    Mean      :math:`\mu`
+    Variance  :math:`\sigma^2`
+    ========  ==========================================
+
+    Normal distribution has 2 alternative parameterizations. In terms of mean and
+    sigma (standard deviation), or mean and tau (precision).
+
+    The link between the 2 alternatives is given by
+
+    .. math::
+
+        \tau = \frac{1}{\sigma^2}
+
+    Parameters
+    ----------
+    mu : float
+        Mean.
+    sigma : float
+        Standard deviation (sigma > 0).
+    tau : float
+        Precision (tau > 0).
+    """
+
+    def __init__(self, mu=None, sigma=None, tau=None):
+        super().__init__()
+        self.support = (-np.inf, np.inf)
+        self._parametrization(mu, sigma, tau)
+
+    def _parametrization(self, mu=None, sigma=None, tau=None):
+        if all_not_none(sigma, tau):
+            raise ValueError(
+                "Incompatible parametrization. Either use mu and sigma, or mu and tau."
+            )
+
+        names = ("mu", "sigma")
+        self.params_support = ((-np.inf, np.inf), (eps, np.inf))
+
+        if tau is not None:
+            self.tau = tau
+            sigma = from_precision(tau)
+            names = ("mu", "tau")
+
+        self.mu = mu
+        self.sigma = sigma
+        self.param_names = names
+        if all_not_none(mu, sigma):
+            self._update(mu, sigma)
+
+    def _update(self, mu, sigma):
+        self.mu = np.float64(mu)
+        self.sigma = np.float64(sigma)
+        self.tau = to_precision(sigma)
+
+        if self.param_names[1] == "sigma":
+            self.params = (self.mu, self.sigma)
+        elif self.param_names[1] == "tau":
+            self.params = (self.mu, self.tau)
+
+        self.is_frozen = True
+
+    def pdf(self, x):
+        """
+        Compute the probability density function (PDF) at a given point x.
+        """
+        return nb_pdf(x, self.mu, self.sigma)
+
+    def cdf(self, x):
+        """
+        Compute the cumulative distribution function (CDF) at a given point x.
+        """
+        return nb_cdf(x, self.mu, self.sigma)
+
+    def ppf(self, q):
+        """
+        Compute the percent point function (PPF) at a given probability q.
+        """
+        return nb_ppf(q, self.mu, self.sigma)
+
+    def logpdf(self, x):
+        """
+        Compute the log probability density function (log PDF) at a given point x.
+        """
+        return _logpdf(x, self.mu, self.sigma)
+
+    def entropy(self):
+        return nb_entropy(self.sigma)
+
+    def mean(self):
+        return self.mu
+
+    def median(self):
+        return self.mu
+
+    def var(self):
+        return self.sigma**2
+
+    def std(self):
+        return self.sigma
+
+    def skewness(self):
+        return 0
+
+    def kurtosis(self):
+        return 0
+
+    def rvs(self, size=1, random_state=None):
+        random_state = np.random.default_rng(random_state)
+        return random_state.normal(self.mu, self.sigma, size)
+
+    def _fit_moments(self, mean, sigma):
+        self._update(mean, sigma)
+
+    def _fit_mle(self, sample):
+        self._update(*nb_fit_mle(sample))
+
+
+# @nb.jit
+# erf not supported by numba
+def nb_cdf(x, mu, sigma):
+    x = np.asarray(x)
+    return 0.5 * (1 + erf((x - mu) / (sigma * 2**0.5)))
+
+
+# @nb.jit
+# erfinv not supported by numba
+def nb_ppf(q, mu, sigma):
+    q = np.asarray(q)
+    return mu + sigma * 2**0.5 * erfinv(2 * q - 1)
+
+
+@nb.njit
+def nb_pdf(x, mu, sigma):
+    x = np.asarray(x)
+    return 1 / np.sqrt(2 * np.pi * sigma**2) * np.exp(-0.5 * ((x - mu) / sigma) ** 2)
+
+
+@nb.njit
+def nb_entropy(sigma):
+    return 0.5 * (np.log(2 * np.pi * np.e * sigma**2))
+
+
+@nb.njit
+def nb_fit_mle(sample):
+    return np.mean(sample), np.std(sample)
+
+
+@nb.njit
+def _logpdf(x, mu, sigma):
+    x = np.asarray(x)
+    return -np.log(sigma) - 0.5 * np.log(2 * np.pi) - 0.5 * ((x - mu) / sigma) ** 2

--- a/preliz/distributions/normal.py
+++ b/preliz/distributions/normal.py
@@ -2,7 +2,7 @@
 # pylint: disable=arguments-differ
 import numba as nb
 import numpy as np
-from scipy.special import erf, erfinv  # pylint disable=no-name-in-module
+from scipy.special import erf, erfinv  # pylint: disable=no-name-in-module
 
 from .distributions import Continuous
 from ..internal.distribution_helper import eps, to_precision, from_precision, all_not_none

--- a/preliz/distributions/normal.py
+++ b/preliz/distributions/normal.py
@@ -1,5 +1,5 @@
 # pylint: disable=attribute-defined-outside-init
-# arguments-differ
+# pylint: disable=arguments-differ
 import numba as nb
 import numpy as np
 from scipy.special import erf, erfinv  # pylint disable=no-name-in-module

--- a/preliz/distributions/normal.py
+++ b/preliz/distributions/normal.py
@@ -1,6 +1,8 @@
+# pylint: disable=attribute-defined-outside-init
+# arguments-differ
 import numba as nb
 import numpy as np
-from scipy.special import erf, erfinv
+from scipy.special import erf, erfinv  # pylint disable=no-name-in-module
 
 from .distributions import Continuous
 from ..internal.distribution_helper import eps, to_precision, from_precision, all_not_none

--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -3,6 +3,19 @@ import numpy as np
 from scipy.special import gamma
 
 
+eps = np.finfo(float).eps
+
+
+def from_precision(precision):
+    sigma = 1 / precision**0.5
+    return sigma
+
+
+def to_precision(sigma):
+    precision = 1 / sigma**2
+    return precision
+
+
 def hdi_from_pdf(dist, mass=0.94):
     """
     Approximate the HDI by evaluating the pdf.
@@ -12,12 +25,12 @@ def hdi_from_pdf(dist, mass=0.94):
     if dist.kind == "continuous":
         lower_ep, upper_ep = dist._finite_endpoints("full")
         x_vals = np.linspace(lower_ep, upper_ep, 10000)
-        pdf = dist.rv_frozen.pdf(x_vals)
+        pdf = dist.pdf(x_vals)
         pdf = pdf[np.isfinite(pdf)]
         pdf = pdf / pdf.sum()
     else:
         x_vals = dist.xvals(support="full")
-        pdf = dist.rv_frozen.pmf(x_vals)
+        pdf = dist.pdf(x_vals)
 
     sorted_idx = np.argsort(pdf)[::-1]
     mass_cum = 0

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -24,7 +24,10 @@ def optimize_max_ent(dist, lower, upper, mass, none_idx, fixed):
     def entropy_loss(params, dist):
         params = get_params(dist, params, none_idx, fixed)
         dist._parametrization(**params)
-        return -dist.rv_frozen.entropy()
+        if dist.rv_frozen is None:
+            return -dist.entropy()
+        else:
+            return -dist.rv_frozen.entropy()
 
     cons = {
         "type": "eq",
@@ -282,10 +285,7 @@ def fit_to_sample(selected_distributions, sample, x_min, x_max):
         if dist._check_endpoints(x_min, x_max, raise_error=False):
             dist._fit_mle(sample)  # pylint:disable=protected-access
             corr = get_penalization(sample_size, dist)
-            if dist.kind == "continuous":
-                loss = -(dist.rv_frozen.logpdf(sample).sum() - corr)
-            else:
-                loss = -(dist.rv_frozen.logpmf(sample).sum() - corr)
+            loss = -(dist.logpdf(sample).sum() - corr)
 
         fitted.update(loss, dist)
 

--- a/preliz/internal/plot_helper.py
+++ b/preliz/internal/plot_helper.py
@@ -72,7 +72,7 @@ def plot_pointinterval(distribution, interval="hdi", levels=None, rotated=False,
                 func = distribution.eti
 
             q_tmp = np.concatenate([func(mass=m) for m in levels])
-            median = distribution.rv_frozen.median()
+            median = distribution.median()
 
         q_s = []
         if len(levels) == 2:

--- a/preliz/tests/test_dist_scipy.py
+++ b/preliz/tests/test_dist_scipy.py
@@ -1,0 +1,50 @@
+import pytest
+from numpy.testing import assert_almost_equal
+import numpy as np
+
+
+from preliz.distributions import Normal
+from scipy import stats
+
+
+@pytest.mark.parametrize(
+    "p_dist, sp_dist, p_params, sp_params",
+    [(Normal, stats.norm, {"mu": 0, "sigma": 2}, {"loc": 0, "scale": 2})],
+)
+def test_lala(p_dist, sp_dist, p_params, sp_params):
+    preliz_dist = p_dist(**p_params)
+    scipy_dist = sp_dist(**sp_params)
+
+    actual = preliz_dist.entropy()
+    expected = scipy_dist.entropy()
+    assert_almost_equal(actual, expected)
+
+    rng = np.random.default_rng(1)
+    actual_rvs = preliz_dist.rvs(100, random_state=rng)
+    rng = np.random.default_rng(1)
+    expected_rvs = scipy_dist.rvs(100, random_state=rng)
+    assert_almost_equal(actual_rvs, expected_rvs)
+
+    actual_pdf = preliz_dist.pdf(actual_rvs)
+    if preliz_dist.kind == "continuous":
+        expected_pdf = scipy_dist.pdf(expected_rvs)
+    else:
+        expected_pdf = scipy_dist.pmf(expected_rvs)
+    assert_almost_equal(actual_pdf, expected_pdf)
+
+    actual_cdf = preliz_dist.cdf(actual_rvs)
+    expected_cdf = scipy_dist.cdf(expected_rvs)
+    assert_almost_equal(actual_cdf, expected_cdf)
+
+    x_vals = np.linspace(0, 1, 10)
+    actual_ppf = preliz_dist.ppf(x_vals)
+    expected_ppf = scipy_dist.ppf(x_vals)
+    assert_almost_equal(actual_ppf, expected_ppf)
+
+    actual_logpdf = preliz_dist.logpdf(actual_rvs)
+    expected_logpdf = scipy_dist.logpdf(expected_rvs)
+    assert_almost_equal(actual_logpdf, expected_logpdf)
+
+    actual_moments = preliz_dist.moments("mvsk")
+    expected_moments = scipy_dist.stats("mvsk")
+    assert_almost_equal(actual_moments, expected_moments)

--- a/preliz/tests/test_distributions.py
+++ b/preliz/tests/test_distributions.py
@@ -112,7 +112,7 @@ def test_moments(distribution, params):
     dist = distribution(*params)
     dist_ = distribution()
 
-    dist_._fit_moments(dist.rv_frozen.mean(), dist.rv_frozen.std())
+    dist_._fit_moments(dist.mean(), dist.std())
 
     tol = 5
     if dist.__class__.__name__ in [
@@ -127,8 +127,8 @@ def test_moments(distribution, params):
         "StudentT",
     ]:
         tol = 0
-    assert_almost_equal(dist.rv_frozen.mean(), dist_.rv_frozen.mean(), tol)
-    assert_almost_equal(dist.rv_frozen.std(), dist_.rv_frozen.std(), tol)
+    assert_almost_equal(dist.mean(), dist_.mean(), tol)
+    assert_almost_equal(dist.std(), dist_.std(), tol)
     assert_almost_equal(params, dist_.params, 0)
 
 
@@ -187,7 +187,7 @@ def test_moments(distribution, params):
 )
 def test_mle(distribution, params):
     dist = distribution(*params)
-    sample = dist.rv_frozen.rvs(20000)
+    sample = dist.rvs(20000)
     dist_ = distribution()
     dist_._fit_mle(sample)
 
@@ -195,8 +195,8 @@ def test_mle(distribution, params):
         tol = 0
     else:
         tol = 1
-    assert_almost_equal(dist.rv_frozen.mean(), dist_.rv_frozen.mean(), tol)
-    assert_almost_equal(dist.rv_frozen.std(), dist_.rv_frozen.std(), tol)
+    assert_almost_equal(dist.mean(), dist_.mean(), tol)
+    assert_almost_equal(dist.std(), dist_.std(), tol)
     if dist.__class__.__name__ == "StudentT":
         assert_almost_equal(params[1:], dist_.params[1:], 0)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ description = "The place for all your prior elicitation needs."
 dependencies = [
   "arviz",
   "matplotlib>=3.5",
+  "numba>=0.59",
   "numpy>=1.22",
   "scipy>=1.9.1",
 ]


### PR DESCRIPTION
Distributions in PreliZ are wrappers around SciPy distributions. This is fine for many situations, but when iterative operations are required like in optimization we could benefit from faster implementations.

This could also be used to avoid duplication of code and efforts, for instance in Kulprit we also need fast logpdf evaluations.
