### PR TITLE
Add truncated distribution

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -81,3 +81,9 @@ This reference provides detailed documentation for user functions in the current
 
 .. automodule:: preliz.distributions.continuous_multivariate
    :members:
+
+:mod:`preliz.distributions`
+====================================
+
+.. automodule:: preliz.distributions.truncated
+   :members:

--- a/preliz/distributions/__init__.py
+++ b/preliz/distributions/__init__.py
@@ -1,6 +1,7 @@
 from .continuous import *
 from .discrete import *
 from .continuous_multivariate import *
+from .truncated import Truncated
 
 all_continuous = [
     AsymmetricLaplace,
@@ -57,4 +58,5 @@ __all__ = (
     [s.__name__ for s in all_continuous]
     + [s.__name__ for s in all_discrete]
     + [s.__name__ for s in all_continuous_multivariate]
+    + [Truncated.__name__]
 )

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -515,7 +515,7 @@ class Distribution:
         else:
             args = init_vals[self.__class__.__name__]
 
-        self.__init__(**args)  # pylint: disable=unnecessary-dunder-call
+        self._parametrization(**args)
 
         if xy_lim == "both":
             xlim = self._finite_endpoints("full")
@@ -551,7 +551,7 @@ class Distribution:
                 if np.sum(values) > 1:
                     return None
 
-            self.__init__(**args)  # pylint: disable=unnecessary-dunder-call
+            self._parametrization(**args)
 
             if kind == "pdf":
                 ax = self.plot_pdf(
@@ -714,7 +714,9 @@ class TruncatedCensored(Distribution):
             raise ValueError("Invalid format string.")
 
         if valid_scalar_params(self):
-            attr = namedtuple(self.__class__.__name__, ["median", "lower", "upper"])
+            attr = namedtuple(
+                "Truncated" + self.dist.__class__.__name__, ["median", "lower", "upper"]
+            )
             median = float(f"{self.median():{fmt}}")
             eti = self.eti(mass)
             lower_tail = float(f"{eti[0]:{fmt}}")

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -39,6 +39,8 @@ class Distribution:
 
     def __repr__(self):
         name = self.__class__.__name__
+        if name == "Truncated":
+            name += self.dist.__class__.__name__
         if self.is_frozen:
             bolded_name = "\033[1m" + name + "\033[0m"
 

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -758,28 +758,28 @@ class TruncatedCensored(Distribution):
             return discrete_xvals(lower_ep, upper_ep, n_points)
 
     def mean(self):
-        """Mean of the distribution."""
+        """Mean of the distribution. Not implemented."""
         return NotImplemented
 
     def std(self):
-        """Standard deviation of the distribution."""
+        """Standard deviation of the distribution. Not implemented."""
         return NotImplemented
 
     def var(self):
-        """Variance of the distribution."""
+        """Variance of the distribution. Not implemented."""
         return NotImplemented
 
     def skewness(self):
-        """Skewness of the distribution."""
+        """Skewness of the distribution. Not implemented."""
         return NotImplemented
 
     def kurtois(self):
-        """Kurtosis of the distribution"""
+        """Kurtosis of the distribution. Not implemented."""
         return NotImplemented
 
     def moments(self, types="mvsk"):
         """
-        Compute moments of the distribution.
+        Compute moments of the distribution. Not implemented.
         """
         return NotImplemented
 

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -3,6 +3,7 @@ Parent classes for all families.
 """
 # pylint: disable=no-member
 from collections import namedtuple
+from copy import copy
 
 try:
     from ipywidgets import interactive
@@ -513,9 +514,14 @@ class Distribution:
         if valid_scalar_params(self, check_frozen=False):
             args = dict(zip(self.param_names, self.params))
         else:
-            args = init_vals[self.__class__.__name__]
-
-        self._parametrization(**args)
+            name = self.__class__.__name__
+            if name == "Truncated":
+                vals = copy(init_vals["Truncated"])
+                vals.update(init_vals[self.dist.__class__.__name__])
+                self._parametrization(**vals)
+            else:
+                args = init_vals[self.__class__.__name__]
+                self._parametrization(**args)
 
         if xy_lim == "both":
             xlim = self._finite_endpoints("full")

--- a/preliz/distributions/truncated.py
+++ b/preliz/distributions/truncated.py
@@ -1,0 +1,77 @@
+# pylint: disable=arguments-differ
+import numpy as np
+from preliz.distributions.distributions import TruncatedCensored
+
+
+class Truncated(TruncatedCensored):
+    r"""
+    Truncated distribution
+
+    The pdf of a censored distribution is
+
+    .. math::
+
+        \begin{cases}
+            0 & \text{for } x < lower, \\
+            \frac{\text{PDF}(x, dist)}{\text{CDF}(upper, dist) - \text{CDF}(lower, dist)}
+            & \text{for } lower <= x <= upper, \\
+            0 & \text{for } x > upper,
+        \end{cases}
+
+    Parameters
+    ----------
+    dist: PreliZ distribution
+        Univariate PreliZ distribution which will be truncated.
+    lower: float or int 
+        Lower (left) truncation point. Use np.inf for no truncation.
+    upper: float or int 
+        Upper (right) truncation point. Use np.inf for no truncation.
+    """
+
+    def __init__(self, dist, lower, upper):
+        self.dist = dist
+        super().__init__()
+        if self.kind == "discrete":
+            self.lower = lower - 1
+        else:
+            self.lower = lower
+        self.upper = upper
+        self.is_frozen = True
+        self.params = (*self.dist.params, self.lower, self.upper)
+        self.param_names = (*self.dist.param_names, "lower", "upper")
+        self.support = (
+            max(self.dist.support[0], self.lower),
+            min(self.dist.support[1], self.upper),
+        )
+
+    def rvs(self, size=1, random_state=None):
+        random_state = np.random.default_rng(random_state)
+        return self.ppf(random_state.uniform(size=size))
+
+    def pdf(self, x):
+        x = np.asarray(x)
+        vals = self.dist.pdf(x) / (self.dist.cdf(self.upper) - self.dist.cdf(self.lower))
+        return np.where((x < self.lower) | (x > self.upper), 0, vals)
+
+    def cdf(self, x):
+        x = np.asarray(x)
+        lcdf = self.dist.cdf(self.lower)
+        vals = (self.dist.cdf(x) - lcdf) / (self.dist.cdf(self.upper) - lcdf)
+        return np.where(x < self.lower, 0, np.where(x > self.upper, 1, vals))
+
+    def ppf(self, q):
+        q = np.asarray(q)
+        lcdf = self.dist.cdf(self.lower)
+        vals = self.dist.ppf(lcdf + q * (self.dist.cdf(self.upper) - lcdf))
+        return np.where((q < 0) | (q > 1), np.nan, vals)
+
+    def logpdf(self, x):
+        x = np.asarray(x)
+        vals = self.dist.logpdf(x) - np.log(self.dist.cdf(self.upper) - self.dist.cdf(self.lower))
+        return np.where((x < self.lower) | (x > self.upper), -np.inf, vals)
+
+    def _neg_logpdf(self, x):
+        return -self.logpdf(x).sum()
+
+    def median(self):
+        return self.ppf(0.5)

--- a/preliz/distributions/truncated.py
+++ b/preliz/distributions/truncated.py
@@ -1,13 +1,15 @@
 # pylint: disable=arguments-differ
 import numpy as np
+
 from preliz.distributions.distributions import TruncatedCensored
+from preliz.internal.distribution_helper import all_not_none
 
 
 class Truncated(TruncatedCensored):
     r"""
     Truncated distribution
 
-    The pdf of a censored distribution is
+    The pdf of a Truncated distribution is
 
     .. math::
 
@@ -18,73 +20,120 @@ class Truncated(TruncatedCensored):
             0 & \text{for } x > upper,
         \end{cases}
 
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        from preliz import Gamma, Truncated
+        az.style.use('arviz-doc')
+        Truncated(Gamma(mu=2, sigma=1), 1, 4.5).plot_pdf()
+        Gamma(mu=2, sigma=1).plot_pdf()
+        
+
     Parameters
     ----------
     dist: PreliZ distribution
         Univariate PreliZ distribution which will be truncated.
-    lower: float or int 
+    lower: float or int
         Lower (left) truncation point. Use np.inf for no truncation.
-    upper: float or int 
+    upper: float or int
         Upper (right) truncation point. Use np.inf for no truncation.
+
+    Note
+    ----
+
+    Some methods like mean or variance are not available truncated distributions.
+    Functions like maxent or quantile are experimental when applied to  truncated
+    distributions and may not work as expected.
     """
 
-    def __init__(self, dist, lower, upper, **kwargs):
+    def __init__(self, dist, lower=None, upper=None, **kwargs):
         self.dist = dist
         super().__init__()
-        if not kwargs:
-            kwargs = dict(zip(self.dist.param_names, self.dist.params))
-
         self._parametrization(lower, upper, **kwargs)
 
-    def _parametrization(self, lower, upper, **kwargs):
+    def _parametrization(self, lower=None, upper=None, **kwargs):
         dist_params = []
+        if not kwargs:
+            if hasattr(self.dist, "params"):
+                kwargs = dict(zip(self.dist.param_names, self.dist.params))
+            else:
+                kwargs = dict(zip(self.dist.param_names, [None] * len(self.dist.param_names)))
+
         for key, value in kwargs.items():
             dist_params.append(value)
             setattr(self, key, value)
 
-        self.dist._parametrization(**kwargs)
-        if self.kind == "discrete":
-            self.lower = lower - 1
+        if upper is None:
+            self.upper = np.inf
+        else:
+            self.upper = upper
+
+        if lower is None:
+            self.lower = -np.inf
         else:
             self.lower = lower
-        self.upper = upper
+
         self.params = (*dist_params, self.lower, self.upper)
         self.param_names = (*self.dist.param_names, "lower", "upper")
+        if all_not_none(*dist_params):
+            self.dist._parametrization(**kwargs)
+            self.is_frozen = True
+
         self.support = (
             max(self.dist.support[0], self.lower),
             min(self.dist.support[1], self.upper),
         )
         self.params_support = (*self.dist.params_support, self.dist.support, self.dist.support)
-        self.is_frozen = True
+
+    def median(self):
+        return self.ppf(0.5)
 
     def rvs(self, size=1, random_state=None):
         random_state = np.random.default_rng(random_state)
         return self.ppf(random_state.uniform(size=size))
 
     def pdf(self, x):
-        x = np.asarray(x)
-        vals = self.dist.pdf(x) / (self.dist.cdf(self.upper) - self.dist.cdf(self.lower))
-        return np.where((x < self.lower) | (x > self.upper), 0, vals)
+        return np.exp(self.logpdf(x))
 
     def cdf(self, x):
         x = np.asarray(x)
-        lcdf = self.dist.cdf(self.lower)
+        lower = adjust_lower(self.kind, self.lower)
+        lcdf = self.dist.cdf(lower)
         vals = (self.dist.cdf(x) - lcdf) / (self.dist.cdf(self.upper) - lcdf)
-        return np.where(x < self.lower, 0, np.where(x > self.upper, 1, vals))
+        return np.where(x < lower, 0, np.where(x > self.upper, 1, vals))
 
     def ppf(self, q):
         q = np.asarray(q)
-        lcdf = self.dist.cdf(self.lower)
+        lower = adjust_lower(self.kind, self.lower)
+        lcdf = self.dist.cdf(lower)
         vals = self.dist.ppf(lcdf + q * (self.dist.cdf(self.upper) - lcdf))
         return np.where((q < 0) | (q > 1), np.nan, vals)
 
     def logpdf(self, x):
         x = np.asarray(x)
-        vals = self.dist.logpdf(x) - np.log(self.dist.cdf(self.upper) - self.dist.cdf(self.lower))
+        lower = adjust_lower(self.kind, self.lower)
+        vals = self.dist.logpdf(x) - np.log(self.dist.cdf(self.upper) - self.dist.cdf(lower))
         return np.where((x < self.lower) | (x > self.upper), -np.inf, vals)
+
+    def entropy(self):
+        """
+        This is the entropy of the untruncated distribution
+        """
+        if self.dist.rv_frozen is None:
+            return self.dist.entropy()
+        else:
+            return self.dist.rv_frozen.entropy()
 
     def _neg_logpdf(self, x):
         return -self.logpdf(x).sum()
 
-    def median(self):
-        return self.ppf(0.5)
+    def _fit_moments(self, mean, sigma):
+        self.dist._fit_moments(mean, sigma)
+        self._parametrization(**dict(zip(self.dist.param_names, self.dist.params)))
+
+
+def adjust_lower(kind, lower):
+    if kind == "discrete":
+        lower -= 1
+    return lower

--- a/preliz/distributions/truncated.py
+++ b/preliz/distributions/truncated.py
@@ -9,6 +9,8 @@ class Truncated(TruncatedCensored):
     r"""
     Truncated distribution
 
+    This is not a distribution per se, but a modifier of univariate distributions.
+
     The pdf of a Truncated distribution is
 
     .. math::
@@ -118,7 +120,7 @@ class Truncated(TruncatedCensored):
 
     def entropy(self):
         """
-        This is the entropy of the untruncated distribution
+        This is the entropy of the UNtruncated distribution
         """
         if self.dist.rv_frozen is None:
             return self.dist.entropy()

--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -143,4 +143,5 @@ init_vals = {
     "ZeroInflatedBinomial": {"psi": 0.7, "n": 10, "p": 0.5},
     "ZeroInflatedNegativeBinomial": {"psi": 0.7, "mu": 5, "alpha": 8},
     "ZeroInflatedPoisson": {"psi": 0.8, "mu": 4.5},
+    "Truncated": {"lower": -10, "upper": 10},
 }

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -3,6 +3,7 @@ Optimization routines and utilities
 """
 from sys import modules
 import warnings
+from copy import copy
 
 import numpy as np
 from scipy.optimize import minimize, least_squares
@@ -109,7 +110,13 @@ def optimize_moments(dist, mean, sigma, params=None):
     if params is not None:
         dist._update(*params)
     else:
-        dist._update(**default_vals[dist.__class__.__name__])
+        name = dist.__class__.__name__
+        if name == "Truncated":
+            vals = copy(default_vals["Truncated"])
+            vals.update(default_vals[dist.dist.__class__.__name__])
+            dist._parametrization(**vals)
+        else:
+            dist._update(**default_vals[name])
 
     init_vals = np.array(dist.params)[none_idx]
 

--- a/preliz/tests/test_plots.py
+++ b/preliz/tests/test_plots.py
@@ -39,7 +39,7 @@ def test_continuous_plot_pdf_cdf_ppf(two_dist, kwargs):
 
 def test_plot_interactive():
     for idx, distribution in enumerate(pz.distributions.__all__):
-        if distribution not in ["Dirichlet", "MvNormal"]:
+        if distribution not in ["Dirichlet", "MvNormal", "Truncated"]:
             dist = getattr(pz.distributions, distribution)
             kind = ["pdf", "cdf", "ppf"][idx % 3]
             xy_lim = ["auto", "both"][idx % 2]

--- a/preliz/tests/test_plots.py
+++ b/preliz/tests/test_plots.py
@@ -44,6 +44,9 @@ def test_plot_interactive():
             kind = ["pdf", "cdf", "ppf"][idx % 3]
             xy_lim = ["auto", "both"][idx % 2]
             dist().plot_interactive(kind=kind, xy_lim=xy_lim)
+        if distribution == "Truncated":
+            dist = getattr(pz.distributions, distribution)
+            dist(pz.Normal(0, 2), -1, 1).plot_interactive(kind="pdf", xy_lim="both")
 
 
 @pytest.mark.parametrize(

--- a/preliz/tests/test_truncated_censored.py
+++ b/preliz/tests/test_truncated_censored.py
@@ -1,0 +1,43 @@
+from numpy.testing import assert_almost_equal
+import numpy as np
+
+from preliz.distributions import Truncated, TruncatedNormal, Normal
+
+
+def test_truncated():
+    custom_truncnorm_dist = Truncated(Normal(0, 2), -1, np.inf)
+    genera_truncnorm_dist = TruncatedNormal(0, 2, -1, np.inf)
+
+    rng = np.random.default_rng(1)
+    actual_rvs = custom_truncnorm_dist.rvs(20, random_state=rng)
+    rng = np.random.default_rng(1)
+    expected_rvs = genera_truncnorm_dist.rvs(20, random_state=rng)
+    assert_almost_equal(actual_rvs, expected_rvs)
+
+    actual_pdf = custom_truncnorm_dist.pdf(actual_rvs)
+    expected_pdf = genera_truncnorm_dist.pdf(actual_rvs)
+    assert_almost_equal(actual_pdf, expected_pdf, decimal=4)
+
+    support = custom_truncnorm_dist.support
+    cdf_vals = np.concatenate([actual_rvs, support, [support[0] - 1], [support[1] + 1]])
+
+    actual_cdf = custom_truncnorm_dist.cdf(cdf_vals)
+    expected_cdf = genera_truncnorm_dist.cdf(cdf_vals)
+    assert_almost_equal(actual_cdf, expected_cdf, decimal=6)
+
+    x_vals = [-1, 0, 0.25, 0.5, 0.75, 1, 2]
+    actual_ppf = custom_truncnorm_dist.ppf(x_vals)
+    expected_ppf = genera_truncnorm_dist.ppf(x_vals)
+    assert_almost_equal(actual_ppf, expected_ppf)
+
+    actual_logpdf = custom_truncnorm_dist.logpdf(actual_rvs)
+    expected_logpdf = genera_truncnorm_dist.logpdf(actual_rvs)
+    assert_almost_equal(actual_logpdf, expected_logpdf)
+
+    actual_neg_logpdf = custom_truncnorm_dist._neg_logpdf(actual_rvs)
+    expected_neg_logpdf = -expected_logpdf.sum()
+    assert_almost_equal(actual_neg_logpdf, expected_neg_logpdf)
+
+    actual_median = custom_truncnorm_dist.median()
+    expected_median = genera_truncnorm_dist.median()
+    assert_almost_equal(actual_median, expected_median)


### PR DESCRIPTION
This is not a distribution per se, instead modifies distributions. For instance

pz.Truncated(pz.Poisson(4.5), 1, 10) 

is a Poisson distribution truncated at a lower value of 1 and an upper value of 10. 

Methods like `plot_pdf` and `hdi` work, but others like mean and variance are not available. It works with `pz.maxent`  or `pz.quartile`. For maxent the approximation I am using is to comoute the entropy of the underlying untruncated distribution, I need to better understand when this will fail.

This is not intended to replace the distribution TruncatedNormal, while this is a general method to obtain truncated distribution, TruncatedNormal implements methods like mean, entropy, etc not directly available with this general approach