### PR TITLE
Add Hurdle distribution

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -127,5 +127,8 @@ This reference provides detailed documentation for user functions in the current
 .. automodule:: preliz.distributions.censored
    :members:
 
+.. automodule:: preliz.distributions.hurdle
+   :members:
+
 .. automodule:: preliz.distributions.truncated
    :members:

--- a/preliz/distributions/__init__.py
+++ b/preliz/distributions/__init__.py
@@ -3,6 +3,7 @@ from .discrete import *
 from .continuous_multivariate import *
 from .truncated import Truncated
 from .censored import Censored
+from .hurdle import Hurdle
 
 all_continuous = [
     AsymmetricLaplace,
@@ -61,4 +62,5 @@ __all__ = (
     + [s.__name__ for s in all_continuous_multivariate]
     + [Truncated.__name__]
     + [Censored.__name__]
+    + [Hurdle.__name__]
 )

--- a/preliz/distributions/censored.py
+++ b/preliz/distributions/censored.py
@@ -1,13 +1,13 @@
 # pylint: disable=arguments-differ
 import numpy as np
 
-from preliz.distributions.distributions import TruncatedCensored
+from preliz.distributions.distributions import DistributionTransformer
 from preliz.internal.distribution_helper import all_not_none
 from preliz.internal.special import xlogx, xprody
 from preliz.distributions.truncated import Truncated
 
 
-class Censored(TruncatedCensored):
+class Censored(DistributionTransformer):
     r"""
     Censored distribution
 

--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -40,9 +40,7 @@ class Distribution:
 
     def __repr__(self):
         name = self.__class__.__name__
-        if name == "Truncated":
-            name += self.dist.__class__.__name__
-        elif name == "Censored":
+        if name in ["Truncated", "Censored", "Hurdle"]:
             name += self.dist.__class__.__name__
         if self.is_frozen:
             bolded_name = "\033[1m" + name + "\033[0m"
@@ -701,8 +699,8 @@ class Discrete(Distribution):
         return self.rv_frozen.logpmf(x, *args, **kwds)
 
 
-class TruncatedCensored(Distribution):
-    """Base class for discrete distributions."""
+class DistributionTransformer(Distribution):
+    """Base class for distributions that transform other distributions"""
 
     def __init__(self):
         super().__init__()

--- a/preliz/distributions/hurdle.py
+++ b/preliz/distributions/hurdle.py
@@ -1,0 +1,168 @@
+# pylint: disable=arguments-differ
+import numpy as np
+from preliz.internal.distribution_helper import eps, all_not_none
+
+from ..distributions.distributions import DistributionTransformer
+
+
+class Hurdle(DistributionTransformer):
+    r"""
+    Hurdle distribution
+
+    This is not a distribution per se, but a modifier of univariate distributions.
+
+    Given a base distribution with cumulative distribution function (CDF) and
+    probability density mass/function (PDF). The pdf/pmf of a Hurdle distribution is:
+
+    .. math::
+
+        f(x \mid \psi, \mu) =
+            \left\{
+                \begin{array}{l}
+                (1 - \psi)  \ \text{if } x = 0 \\
+                \psi
+                \frac{\text{PoissonPDF}(x \mid \mu))}
+                {1 - \text{PoissonCDF}(0 \mid \mu)} \ \text{if } x=1,2,3,\ldots
+                \end{array}
+            \right.
+
+    The following figure shows the difference between a Gamma distribution and a HurdleGamma, with
+    the same parameters for the base distribution (Gamma).
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        from preliz import Gamma, Hurdle
+        az.style.use('arviz-doc')
+        Hurdle(Gamma(mu=2, sigma=1), 0.8).plot_pdf()
+        Gamma(mu=2, sigma=1).plot_pdf()
+        
+
+    Parameters
+    ----------
+    dist: PreliZ distribution
+        Univariate PreliZ distribution which will be truncated.
+    psi : float
+        Expected proportion of the base distribution (0 < psi < 1)
+    """
+
+    def __init__(self, dist, psi, **kwargs):
+        self.dist = dist
+        self.psi = psi
+        super().__init__()
+        self._parametrization(**kwargs)
+
+    def _parametrization(self, **kwargs):
+        dist_params = []
+        if not kwargs:
+            if hasattr(self.dist, "params"):
+                kwargs = dict(zip(self.dist.param_names, self.dist.params))
+            else:
+                kwargs = dict(zip(self.dist.param_names, [None] * len(self.dist.param_names)))
+
+        for key, value in kwargs.items():
+            dist_params.append(value)
+            setattr(self, key, value)
+
+        self.params = (*dist_params, self.psi)
+        self.param_names = (*self.dist.param_names, "psi")
+        if all_not_none(*dist_params):
+            self.dist._parametrization(**kwargs)
+            self.is_frozen = True
+
+        self.support = self.dist.support
+        self.params_support = (*self.dist.params_support, (0, 1))
+
+    def mean(self):
+        x_values = self.xvals("full")
+        pdf = self.pdf(x_values)
+        if self.kind == "discrete":
+            return np.sum(x_values * pdf)
+        else:
+            return np.trapz(x_values * pdf, x_values)
+
+    def median(self):
+        return self.ppf(0.5)
+
+    def var(self):
+        x_values = self.xvals("full")
+        pdf = self.pdf(x_values)
+        if self.kind == "discrete":
+            return np.sum((x_values - self.mean()) ** 2 * pdf)
+        else:
+            return np.trapz((x_values - self.mean()) ** 2 * pdf, x_values)
+
+    def std(self):
+        return self.var() ** 0.5
+
+    def rvs(self, size=None, random_state=None):
+        random_state = np.random.default_rng(random_state)
+        return self.ppf(random_state.uniform(size=size))
+
+    def pdf(self, x):
+        if self.dist == "discrete":
+            return np.where(
+                x == 0, 1 - self.psi, self.psi * self.dist.pdf(x) / (1 - self.dist.cdf(0))
+            )
+        else:
+            return np.where(
+                x == 0, 1 - self.psi, self.psi * self.dist.pdf(x) / (1 - self.dist.cdf(eps))
+            )
+
+    def cdf(self, x):
+
+        if self.dist == "discrete":
+            return np.where(
+                x <= 0, 1 - self.psi, 1 - self.psi * (1 - self.dist.cdf(x)) / (1 - self.dist.cdf(0))
+            )
+        else:
+            return np.where(
+                x <= 0,
+                1 - self.psi,
+                1 - self.psi * (1 - self.dist.cdf(x)) / (1 - self.dist.cdf(eps)),
+            )
+
+    def ppf(self, q):
+        if self.kind == "discrete":
+            lower = 0
+        else:
+            lower = eps
+        q = np.asarray(q)
+        psi = self.psi
+        lcdf = self.dist.cdf(lower)
+        vals = np.zeros_like(q)
+        vals[q >= (1 - psi)] = self.dist.ppf(
+            lcdf + (q[q >= (1 - psi)] - (1 - psi)) * (1 - lcdf) / psi
+        )
+        return np.where((q < 0) | (q > 1), np.nan, vals)
+
+    def logpdf(self, x):
+        if self.dist == "discrete":
+            pdf_values = np.where(
+                x == 0,
+                np.log(1 - self.psi),
+                np.log(self.psi) + self.dist.logpdf(x) - np.log(1 - self.dist.cdf(0)),
+            )
+        else:
+            pdf_values = np.where(
+                x == 0,
+                np.log(1 - self.psi),
+                np.log(self.psi) + self.dist.logpdf(x) - np.log(1 - self.dist.cdf(eps)),
+            )
+        return pdf_values
+
+    def entropy(self):
+        x_values = self.xvals("restricted")
+        logpdf = self.logpdf(x_values)
+        if self.kind == "discrete":
+            return -np.sum(np.exp(logpdf) * logpdf)
+        else:
+            return -np.trapz(np.exp(logpdf) * logpdf, x_values)
+
+    def _neg_logpdf(self, x):
+        return -self.logpdf(x).sum()
+
+    def _fit_moments(self, mean, sigma):
+        self.dist._fit_moments(mean, sigma)
+        self._parametrization(**dict(zip(self.dist.param_names, self.dist.params)))

--- a/preliz/distributions/truncated.py
+++ b/preliz/distributions/truncated.py
@@ -1,11 +1,11 @@
 # pylint: disable=arguments-differ
 import numpy as np
 
-from preliz.distributions.distributions import TruncatedCensored
+from preliz.distributions.distributions import DistributionTransformer
 from preliz.internal.distribution_helper import all_not_none
 
 
-class Truncated(TruncatedCensored):
+class Truncated(DistributionTransformer):
     r"""
     Truncated distribution
 

--- a/preliz/internal/plot_helper.py
+++ b/preliz/internal/plot_helper.py
@@ -153,7 +153,6 @@ def plot_pdfpmf(
         else:
             x_c = np.linspace(x[0], x[-1], 1000)
             # if new distribution, directly compute pdf at non-integer values
-            print(dist.__class__.__name__)
             if dist.rv_frozen is None:
                 mass_c = np.clip(dist.pdf(x_c), np.min(mass), np.max(mass))
             # if old, interpolate

--- a/preliz/tests/test_hurdle.py
+++ b/preliz/tests/test_hurdle.py
@@ -1,0 +1,74 @@
+import pytest
+from numpy.testing import assert_almost_equal
+import numpy as np
+
+from preliz.distributions import (
+    Hurdle,
+    Truncated,
+    Gamma,
+    Normal,
+    LogNormal,
+    Poisson,
+    NegativeBinomial,
+)
+from preliz.internal.distribution_helper import eps
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [
+        (Gamma(3, 5)),
+        (LogNormal(0, 0.5)),
+        (Normal(0, 2)),
+        (Poisson(3.5)),
+        (NegativeBinomial(3, 5)),
+    ],
+)
+def test_hurdle_vs_truncated(dist):
+    if dist.kind == "discrete":
+        lower = 1
+    else:
+        lower = eps
+
+    hurdle_dist = Hurdle(dist, 1)
+    base_dist = Truncated(dist, lower=lower, upper=np.inf)
+
+    rng = np.random.default_rng(1)
+    actual_rvs = hurdle_dist.rvs(100_000, random_state=rng)
+    expected_rvs = base_dist.rvs(100_000, random_state=rng)
+    assert_almost_equal(actual_rvs.mean(), expected_rvs.mean(), decimal=2)
+    assert_almost_equal(actual_rvs.var(), expected_rvs.var(), decimal=2)
+
+    assert_almost_equal(hurdle_dist.mean(), base_dist.mean(), decimal=2)
+    assert_almost_equal(hurdle_dist.var(), base_dist.var(), decimal=3)
+    assert_almost_equal(hurdle_dist.std(), base_dist.std(), decimal=4)
+    assert_almost_equal(hurdle_dist.entropy(), base_dist.entropy())
+
+    few_rvs = hurdle_dist.rvs(20, random_state=rng)
+    assert_almost_equal(hurdle_dist.pdf(few_rvs), base_dist.pdf(few_rvs))
+    assert_almost_equal(hurdle_dist.cdf(few_rvs), base_dist.cdf(few_rvs))
+    assert_almost_equal(hurdle_dist.logpdf(few_rvs), base_dist.logpdf(few_rvs))
+    assert_almost_equal(hurdle_dist._neg_logpdf(few_rvs), base_dist._neg_logpdf(few_rvs))
+    x_vals = [-1, 0, 0.25, 0.5, 0.75, 1, 2]
+    assert_almost_equal(hurdle_dist.ppf(x_vals), base_dist.ppf(x_vals))
+
+
+@pytest.mark.parametrize(
+    "dist",
+    [
+        (Gamma(3, 5)),
+        (LogNormal(0, 0.5)),
+        (Normal(0, 2)),
+        (Poisson(3.5)),
+        (NegativeBinomial(3, 5)),
+    ],
+)
+def test_hurdle_vs_random(dist):
+    hurdle_dist = Hurdle(dist, psi=0.7)
+
+    rng = np.random.default_rng(1)
+    rvs = hurdle_dist.rvs(500_000, random_state=rng)
+
+    assert_almost_equal(hurdle_dist.mean(), rvs.mean(), decimal=2)
+    assert_almost_equal(hurdle_dist.var(), rvs.var(), decimal=0)
+    assert_almost_equal(hurdle_dist.std(), rvs.std(), decimal=0)

--- a/preliz/tests/test_plots.py
+++ b/preliz/tests/test_plots.py
@@ -39,7 +39,7 @@ def test_continuous_plot_pdf_cdf_ppf(two_dist, kwargs):
 
 def test_plot_interactive():
     for idx, distribution in enumerate(pz.distributions.__all__):
-        if distribution not in ["Dirichlet", "MvNormal", "Truncated", "Censored"]:
+        if distribution not in ["Dirichlet", "MvNormal", "Truncated", "Censored", "Hurdle"]:
             dist = getattr(pz.distributions, distribution)
             kind = ["pdf", "cdf", "ppf"][idx % 3]
             xy_lim = ["auto", "both"][idx % 2]
@@ -47,6 +47,9 @@ def test_plot_interactive():
         if distribution in ["Truncated", "Censored"]:
             dist = getattr(pz.distributions, distribution)
             dist(pz.Normal(0, 2), -1, 1).plot_interactive(kind="pdf", xy_lim="both")
+        if distribution == "Hurdle":
+            dist = getattr(pz.distributions, distribution)
+            dist(pz.Normal(0, 2), 0.9).plot_interactive(kind="pdf", xy_lim="both")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds a Hurdle distribution. Following the same logic as the Censored and Truncated, the hurdle distribution acts a modifier or the base distribution. The hurdle distribution can be considered as a lower_bounded truncated distribution (at 0 for discrete distribution and "very close to 0" for continuous) + a 1-psi proportion of zeros.

Closes #340
Closes #341
Closes #342
Closes #343 
