### PR TITLE
Add eficient hypergeometric

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -117,6 +117,9 @@ This reference provides detailed documentation for user functions in the current
 .. automodule:: preliz.distributions.geometric
    :members:
 
+.. automodule:: preliz.distributions.hypergeometric
+   :members:
+
 .. automodule:: preliz.distributions.poisson
    :members:
 

--- a/preliz/distributions/hypergeometric.py
+++ b/preliz/distributions/hypergeometric.py
@@ -1,0 +1,202 @@
+# pylint: disable=attribute-defined-outside-init
+# pylint: disable=arguments-differ
+# pylint: disable=invalid-name
+import numba as nb
+import numpy as np
+from .distributions import Discrete
+
+from ..internal.special import betaln, cdf_bounds
+from ..internal.optimization import optimize_ml, optimize_moments, find_ppf
+from ..internal.distribution_helper import all_not_none
+
+eps = np.finfo(float).eps
+
+
+class HyperGeometric(Discrete):
+    R"""
+    Discrete hypergeometric distribution.
+
+    The probability of :math:`x` successes in a sequence of :math:`n` bernoulli
+    trials taken without replacement from a population of :math:`N` objects,
+    containing :math:`k` good (or successful or Type I) objects.
+    The pmf of this distribution is
+
+    .. math:: f(x \mid N, n, k) = \frac{\binom{k}{x}\binom{N-k}{n-x}}{\binom{N}{n}}
+
+    .. plot::
+        :context: close-figs
+
+        import arviz as az
+        from preliz import HyperGeometric
+        az.style.use('arviz-doc')
+        N = 50
+        k = 10
+        for n in [20, 25]:
+            HyperGeometric(N, k, n).plot_pdf(support=(1,15))
+
+    ========  =============================
+    Support   :math:`x \in \left[\max(0, n - N + k), \min(k, n)\right]`
+    Mean      :math:`\dfrac{nk}{N}`
+    Variance  :math:`\dfrac{(N-n)nk(N-k)}{(N-1)N^2}`
+    ========  =============================
+
+    Parameters
+    ----------
+    N : int
+        Total size of the population (N > 0)
+    k : int
+        Number of successful individuals in the population (0 <= k <= N)
+    n : int
+        Number of samples drawn from the population (0 <= n <= N)
+    """
+
+    def __init__(self, N=None, k=None, n=None):
+        super().__init__()
+        self.support = (0, np.inf)
+        self._parametrization(N, k, n)
+
+    def _parametrization(self, N=None, k=None, n=None):
+        self.N = N
+        self.k = k
+        self.n = n
+        self.param_names = ("N", "k", "n")
+        self.params_support = ((eps, np.inf), (eps, self.N), (eps, self.N))
+        if all_not_none(self.N, self.k, self.n):
+            self._update(N, k, n)
+
+    def _update(self, N, k, n):
+        self.N = np.int64(N)
+        self.k = np.int64(k)
+        self.n = np.int64(n)
+        self.params = (self.N, self.k, self.n)
+        self.support = (max(0, n - N + k), min(k, n))
+        self.is_frozen = True
+
+    def pdf(self, x):
+        """
+        Compute the probability density function (PDF) at a given point x.
+        """
+        x = np.asarray(x)
+        return np.exp(self.logpdf(x))
+
+    def cdf(self, x):
+        """
+        Compute the cumulative distribution function (CDF) at a given point x.
+        """
+        if isinstance(x, (np.ndarray, list, tuple)):
+            cdf_values = np.zeros_like(x, dtype=float)
+            for i, val in enumerate(x):
+                x_vals = np.arange(self.support[0], val + 1)
+                cdf_values[i] = np.sum(self.pdf(x_vals))
+            return cdf_bounds(cdf_values, x, *self.support)
+        else:
+            x_vals = np.arange(self.support[0], x + 1)
+            return cdf_bounds(np.sum(self.pdf(x_vals)), x, *self.support)
+
+    def ppf(self, q):
+        """
+        Compute the percent point function (PPF) at a given probability q.
+        """
+        q = np.asarray(q)
+        return find_ppf(self, q)
+
+    def logpdf(self, x):
+        """
+        Compute the log probability density function (log PDF) at a given point x.
+        """
+        return nb_logpdf(x, self.N, self.k, self.n, *self.support)
+
+    def _neg_logpdf(self, x):
+        """
+        Compute the neg log_pdf sum for the array x.
+        """
+        return nb_neg_logpdf(x, self.N, self.k, self.n, *self.support)
+
+    def entropy(self):
+        x_values = self.xvals("full")
+        logpdf = self.logpdf(x_values)
+        return -np.sum(np.exp(logpdf) * logpdf)
+
+    def mean(self):
+        return self.n * self.k / self.N
+
+    def median(self):
+        return self.ppf(0.5)
+
+    def var(self):
+        return (
+            self.n * self.k / self.N * (self.N - self.k) / self.N * (self.N - self.n) / (self.N - 1)
+        )
+
+    def std(self):
+        return self.var() ** 0.5
+
+    def skewness(self):
+        numerator = (self.N - 2 * self.k) * (self.N - 1) ** 0.5 * (self.N - 2 * self.n)
+        denominator = (self.n * self.k * (self.N - self.k) * (self.N - self.n)) ** 0.5 * (
+            self.N - 2
+        )
+        return numerator / denominator
+
+    def kurtosis(self):
+        return (
+            1
+            / (
+                self.n
+                * self.k
+                * (self.N - self.k)
+                * (self.N - self.n)
+                * (self.N - 2)
+                * (self.N - 3)
+            )
+            * (
+                (self.N - 1)
+                * self.N**2
+                * (
+                    self.N * (self.N + 1)
+                    - 6 * self.k * (self.N - self.k)
+                    - 6 * self.n * (self.N - self.n)
+                )
+                + 6 * self.n * self.k * (self.N - self.k) * (self.N - self.n) * (5 * self.N - 6)
+            )
+        )
+
+    def rvs(self, size=None, random_state=None):
+        random_state = np.random.default_rng(random_state)
+        return random_state.hypergeometric(self.k, self.N - self.k, self.n, size=size)
+
+    def _fit_moments(self, mean, sigma):
+        n = mean + sigma * 4
+        k = n
+        N = k * n / mean
+        params = N, k, n
+        optimize_moments(self, mean, sigma, params)
+
+    def _fit_mle(self, sample):
+        optimize_ml(self, sample)
+
+
+@nb.vectorize(nopython=True, cache=True)
+def nb_logpdf(x, N, k, n, lower, upper):
+    if x < lower:
+        return -np.inf
+    if x > upper:
+        return -np.inf
+    else:
+        good = k
+        bad = N - k
+        tot = good + bad
+        result = (
+            betaln(good + 1, 1)
+            + betaln(bad + 1, 1)
+            + betaln(tot - n + 1, n + 1)
+            - betaln(x + 1, good - x + 1)
+            - betaln(n - x + 1, bad - n + x + 1)
+            - betaln(tot + 1, 1)
+        )
+        return result
+
+
+@nb.njit(cache=True)
+def nb_neg_logpdf(x, N, k, n, lower, upper):
+    return -(nb_logpdf(x, N, k, n, lower, upper)).sum()

--- a/preliz/distributions/wald.py
+++ b/preliz/distributions/wald.py
@@ -7,7 +7,7 @@ from scipy.special import ndtr, expi  # pylint: disable=no-name-in-module
 
 from .distributions import Continuous
 from ..internal.distribution_helper import eps, all_not_none
-from ..internal.special import cdf_bounds, ppf_bounds_cont
+from ..internal.special import cdf_bounds
 from ..internal.optimization import optimize_ml, find_ppf
 
 
@@ -135,7 +135,7 @@ class Wald(Continuous):
         Compute the percent point function (PPF) at a given probability q.
         """
         q = np.asarray(q)
-        return nb_ppf(q, self)
+        return find_ppf(self, q)
 
     def logpdf(self, x):
         """
@@ -188,10 +188,6 @@ def nb_cdf(x, mu, lam):
     v = x / mu
     z = ndtr(u * (v - 1)) + np.exp(2 * lam / mu) * ndtr(-u * (v + 1))
     return cdf_bounds(z, x, 0, np.inf)
-
-
-def nb_ppf(q, dist):
-    return ppf_bounds_cont(find_ppf(dist, q), q, 0, np.inf)
 
 
 def nb_entropy(mu, lam):

--- a/preliz/tests/test_optimization.py
+++ b/preliz/tests/test_optimization.py
@@ -12,6 +12,8 @@ from preliz.distributions import (
     Normal,
     StudentT,
     Weibull,
+    Geometric,
+    Poisson,
 )
 
 
@@ -25,6 +27,8 @@ from preliz.distributions import (
         (Normal, {"mu": 0, "sigma": 2}),
         (StudentT, {"nu": 5, "mu": 0, "sigma": 2}),
         (Weibull, {"alpha": 5.0, "beta": 2.0}),
+        (Geometric, {"p": 0.4}),
+        (Poisson, {"mu": 3.5}),
     ],
 )
 def test_find_ppf(p_dist, p_params):

--- a/preliz/tests/test_scipy.py
+++ b/preliz/tests/test_scipy.py
@@ -33,6 +33,7 @@ from preliz.distributions import (
     Bernoulli,
     Binomial,
     Geometric,
+    HyperGeometric,
     NegativeBinomial,
     Poisson,
     ZeroInflatedBinomial,
@@ -87,6 +88,7 @@ from preliz.distributions import (
         (Bernoulli, stats.bernoulli, {"p": 0.4}, {"p": 0.4}),
         (DiscreteUniform, stats.randint, {"lower": -2, "upper": 1}, {"low": -2, "high": 2}),
         (Geometric, stats.geom, {"p": 0.4}, {"p": 0.4}),
+        (HyperGeometric, stats.hypergeom, {"N": 50, "k": 10, "n": 25}, {"M": 50, "N": 25, "n": 10}),
         (
             NegativeBinomial,
             stats.nbinom,


### PR DESCRIPTION
This adds hypergeometric distribution. Both the cdf and ppf are computed numerically. The ppf is off by one, not sure why as all other tests are passing. In the meantime, I am handling the hypergeometric as a special case. 

This also updates the `find_ppf` function to make it work with discrete distributions.