### PR TITLE
uneven x_vals

### DIFF
--- a/preliz/distributions/distributions.py
+++ b/preliz/distributions/distributions.py
@@ -601,8 +601,21 @@ class Continuous(Distribution):
         n_points : int
             Number of values to return.
         """
-        lower_ep, upper_ep = self._finite_endpoints(support)
-        return continuous_xvals(lower_ep, upper_ep, n_points)
+        if isinstance(support, tuple):
+            return self.ppf(np.linspace(*self.cdf(support), n_points))
+        else:
+            lower_ep, upper_ep = self.support
+
+            if not np.isfinite(lower_ep) or support == "restricted":
+                lower_ep = 0.0001
+            if not np.isfinite(upper_ep) or support == "restricted":
+                upper_ep = 0.9999
+
+            half_n_points = int(n_points / 2)
+            even = np.linspace(*self.ppf([lower_ep, upper_ep]), half_n_points)
+            uneven = self.ppf(np.linspace(lower_ep, upper_ep, half_n_points))
+
+            return np.sort(np.concatenate([even, uneven]))
 
     def _fit_mle(self, sample, **kwargs):
         """

--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -20,6 +20,7 @@ def hdi_from_pdf(dist, mass=0.94):
     This is faster, but potentially less accurate, than directly minimizing the
     interval as evaluating the ppf can be slow, specially for some distributions.
     """
+
     if dist.kind == "continuous":
         lower_ep, upper_ep = dist._finite_endpoints("full")
         x_vals = np.linspace(lower_ep, upper_ep, 10000)
@@ -38,7 +39,11 @@ def hdi_from_pdf(dist, mass=0.94):
         indices.append(idx)
         if mass_cum >= mass:
             break
-    return x_vals[np.sort(indices)[[0, -1]]]
+
+    if indices:
+        return x_vals[np.sort(indices)[[0, -1]]]
+    else:
+        return np.nan, np.nan
 
 
 def all_not_none(*args):

--- a/preliz/tests/test_maxent.py
+++ b/preliz/tests/test_maxent.py
@@ -103,10 +103,10 @@ from preliz.distributions import (
         (Pareto(), 1, 4, 0.9, (1, np.inf), (1.660, 1)),
         (Pareto(m=2), 1, 4, 0.9, (2, np.inf), (3.321)),
         (Rice(), 0, 4, 0.7, (0, np.inf), (0, 2.577)),
-        (Rice(), 1, 10, 0.9, (0, np.inf), (3.453, 3.735)),
+        (Rice(), 1, 10, 0.9, (0, np.inf), (3.454, 3.734)),
         (Rice(nu=4), 0, 6, 0.9, (0, np.inf), (1.402)),
         (SkewNormal(), -2, 10, 0.9, (-np.inf, np.inf), (4.061, 3.648, -0.021)),
-        (SkewNormal(mu=-1), -2, 10, 0.9, (-np.inf, np.inf), (6.293, 4.908)),
+        (SkewNormal(mu=-1), -2, 10, 0.9, (-np.inf, np.inf), (6.292, 4.903)),
         (StudentT(), -1, 1, 0.683, (-np.inf, np.inf), (99.999, 0, 0.994)),
         (StudentT(nu=7), -1, 1, 0.683, (-np.inf, np.inf), (0, 0.928)),
         (


### PR DESCRIPTION
Compute xvals, using a mix of linearspaced and "quantile-spaced" values. This provides nicer plot smoother plots at the bulk and tails for both heavy and thin tails distributions. This also change hdi_from_pdf in order to return nan when computations of the hdi fails (for instance for invalid parameter values like sigma=0). 
