### PR TITLE
Add support for engine="auto" and bambi models in predictive explorer

### DIFF
--- a/preliz/internal/parser.py
+++ b/preliz/internal/parser.py
@@ -4,8 +4,6 @@ import re
 from sys import modules
 
 import numpy as np
-import pymc as pm
-import bambi as bmb
 
 from preliz import distributions
 from .distribution_helper import init_vals
@@ -20,9 +18,9 @@ def inspect_source(fmodel):
         for name, param in signature.parameters.items()
     }
     model = fmodel(**default_params)
-    if isinstance(model, pm.Model):
+    if getattr(model, "basic_RVs", False):
         engine = "pymc"
-    elif isinstance(model, bmb.Model):
+    elif getattr(model, "formula", False):
         engine = "bambi"
     else:
         engine = "preliz"

--- a/preliz/internal/parser.py
+++ b/preliz/internal/parser.py
@@ -24,11 +24,17 @@ def parse_function_for_pred_textboxes(source, signature, engine="preliz"):
     regex = r"\b" + r"\b|\b".join(slidify) + r"\b"
 
     all_dist_str = dist_as_str()
-    matches = match_preliz_dist(all_dist_str, source, "preliz")
+    matches = match_preliz_dist(all_dist_str, source, engine)
 
     for match in matches:
-        dist_name_str = match.group(2)
-        arguments = [s.strip() for s in match.group(3).split(",")]
+        if engine == "bambi":
+            dist_name_str = match.group(1)
+        else:
+            dist_name_str = match.group(2)
+        if engine == "bambi":
+            arguments = [s.strip() for s in match.group(2).split(",")]
+        else:
+            arguments = [s.strip() for s in match.group(3).split(",")]
         if engine == "pymc":
             args = pymc_parse_arguments(arguments, regex)
         else:
@@ -160,10 +166,10 @@ def match_preliz_dist(all_dist_str, source, engine):
     # remove comments
     source = re.sub(r"#.*$|^#.*$", "", source, flags=re.MULTILINE)
 
-    if engine == "preliz":
+    if engine in ["preliz", "pymc"]:
         regex = rf"(.*?({all_dist_str}).*?)\(([^()]*(?:\([^()]*\)[^()]*)*)\)"
     if engine == "bambi":
-        regex = rf'(\w+)\s*=\s*(?:\w+\.)?Prior\("({all_dist_str})",\s*((?:\w+=\w+(?:,?\s*)?)*)\s*\)'
+        regex = rf'\s*(?:\w+\.)?Prior\("({all_dist_str})",\s*((?:\w+=\w+(?:,?\s*)?)*)\s*\)'
     matches = re.finditer(regex, source)
     return matches
 

--- a/preliz/internal/plot_helper.py
+++ b/preliz/internal/plot_helper.py
@@ -442,7 +442,7 @@ def bambi_plot_decorator(func, iterations, kind_plot, references, plot_func):
         model = func(*args, **kwargs)
         model.build()
         with disable_pymc_sampling_logs():
-            idata = model.prior_predictive(iterations, random_seed=iterations)
+            idata = model.prior_predictive(iterations)
         results = extract(idata, group="prior_predictive")[model.response_name].values.T
 
         _, ax = plt.subplots()

--- a/preliz/internal/plot_helper.py
+++ b/preliz/internal/plot_helper.py
@@ -427,9 +427,36 @@ def plot_decorator(func, iterations, kind_plot, references, plot_func):
     return looper
 
 
+def bambi_plot_decorator(func, iterations, kind_plot, references, plot_func):
+    def looper(*args, **kwargs):
+        kwargs.pop("__resample__")
+        x_min = kwargs.pop("__x_min__")
+        x_max = kwargs.pop("__x_max__")
+        if not kwargs.pop("__set_xlim__"):
+            x_min = None
+            x_max = None
+            auto = True
+        else:
+            auto = False
+
+        model = func(*args, **kwargs)
+        model.build()
+        with disable_pymc_sampling_logs():
+            idata = model.prior_predictive(iterations, random_seed=iterations)
+        results = extract(idata, group="prior_predictive")[model.response_name].values.T
+
+        _, ax = plt.subplots()
+        ax.set_xlim(x_min, x_max, auto=auto)
+        if plot_func is None:
+            plot_repr(results, kind_plot, references, iterations, ax)
+        else:
+            plot_func(results, ax)
+
+    return looper
+
+
 def pymc_plot_decorator(func, iterations, kind_plot, references, plot_func):
     def looper(*args, **kwargs):
-        results = []
         kwargs.pop("__resample__")
         x_min = kwargs.pop("__x_min__")
         x_max = kwargs.pop("__x_max__")
@@ -443,11 +470,11 @@ def pymc_plot_decorator(func, iterations, kind_plot, references, plot_func):
             obs_name = model.observed_RVs[0].name
             with disable_pymc_sampling_logs():
                 idata = sample_prior_predictive(samples=iterations)
-            results = extract(idata, group="prior_predictive")[obs_name].values
+            results = extract(idata, group="prior_predictive")[obs_name].values.T
         _, ax = plt.subplots()
         ax.set_xlim(x_min, x_max, auto=auto)
         if plot_func is None:
-            pymc_plot_repr(results, kind_plot, references, iterations, ax)
+            plot_repr(results, kind_plot, references, iterations, ax)
         else:
             plot_func(results, ax)
 
@@ -466,48 +493,6 @@ def plot_repr(results, kind_plot, references, iterations, ax):
             bins = "auto"
         ax.hist(
             results.T,
-            alpha=alpha,
-            density=True,
-            color=["0.5"] * iterations,
-            bins=bins,
-            histtype="step",
-        )
-        ax.hist(
-            np.concatenate(results),
-            density=True,
-            bins=bins,
-            color="k",
-            ls="--",
-            histtype="step",
-        )
-    elif kind_plot == "kde":
-        for result in results:
-            ax.plot(*_kde_linear(result, grid_len=100), "0.5", alpha=alpha)
-        ax.plot(*_kde_linear(np.concatenate(results), grid_len=100), "k--")
-    elif kind_plot == "ecdf":
-        ax.plot(
-            np.sort(results, axis=1).T,
-            np.linspace(0, 1, len(results[0]), endpoint=False),
-            color="0.5",
-        )
-        a = np.concatenate(results)
-        ax.plot(np.sort(a), np.linspace(0, 1, len(a), endpoint=False), "k--")
-
-    plot_references(references, ax)
-
-
-def pymc_plot_repr(results, kind_plot, references, iterations, ax):
-    alpha = max(0.01, 1 - iterations * 0.009)
-
-    if kind_plot == "hist":
-        if results[0].dtype.kind == "i":
-            bins = np.arange(np.min(results), np.max(results) + 1.5) - 0.5
-            if len(bins) < 30:
-                ax.set_xticks(bins + 0.5)
-        else:
-            bins = "auto"
-        ax.hist(
-            results,
             alpha=alpha,
             density=True,
             color=["0.5"] * iterations,

--- a/preliz/internal/predictive_helper.py
+++ b/preliz/internal/predictive_helper.py
@@ -1,5 +1,6 @@
 from sys import modules
 
+import re
 import numpy as np
 
 
@@ -68,3 +69,12 @@ def select_prior_samples(selected, prior_samples, model):
     subsample = {rv: prior_samples[rv][selected] for rv in model.keys()}
 
     return subsample
+
+
+def get_engine(source):
+    source = re.sub(r"#.*$|^#.*$", "", source, flags=re.MULTILINE)
+    if re.search(r"\s*(?:bmb|bambi)\.Model\s*", source):
+        return "bambi"
+    if re.search(r"\s*(?:pm|pymc)\.Model\s*", source):
+        return "pymc"
+    return "preliz"

--- a/preliz/internal/predictive_helper.py
+++ b/preliz/internal/predictive_helper.py
@@ -1,6 +1,5 @@
 from sys import modules
 
-import re
 import numpy as np
 
 
@@ -69,12 +68,3 @@ def select_prior_samples(selected, prior_samples, model):
     subsample = {rv: prior_samples[rv][selected] for rv in model.keys()}
 
     return subsample
-
-
-def get_engine(source):
-    source = re.sub(r"#.*$|^#.*$", "", source, flags=re.MULTILINE)
-    if re.search(r"\s*(?:bmb|bambi)\.Model\s*", source):
-        return "bambi"
-    if re.search(r"\s*(?:pm|pymc)\.Model\s*", source):
-        return "pymc"
-    return "preliz"

--- a/preliz/predictive/predictive_explorer.py
+++ b/preliz/predictive/predictive_explorer.py
@@ -25,8 +25,8 @@ def predictive_explorer(
     Parameters
     ----------
     fmodel : callable
-        A function with PreliZ distributions, PyMC distributions, or Bambi distributions.
-        The PreliZ distributions should call their rvs method.
+        A function with a PreliZ model, a PyMC model, or a Bambi model.
+        See examples section below for details
     samples : int, optional
         The number of samples to draw from the prior predictive distribution (default is 50).
     kind_plot : str, optional

--- a/preliz/predictive/predictive_explorer.py
+++ b/preliz/predictive/predictive_explorer.py
@@ -10,7 +10,6 @@ from preliz.internal.plot_helper import (
     pymc_plot_decorator,
     bambi_plot_decorator,
 )
-from preliz.internal.predictive_helper import get_engine
 
 
 def predictive_explorer(
@@ -44,8 +43,7 @@ def predictive_explorer(
         The function will automatically select the appropriate library to use based on the fmodel
         provided.
     """
-    source, signature = inspect_source(fmodel)
-    engine = get_engine(source) if engine == "auto" else engine
+    source, signature, engine = inspect_source(fmodel)
     model = parse_function_for_pred_textboxes(source, signature, engine)
     textboxes = get_textboxes(signature, model)
     if engine == "pymc":

--- a/preliz/tests/predictive_explorer.ipynb
+++ b/preliz/tests/predictive_explorer.ipynb
@@ -15,6 +15,9 @@
     "import numpy as np\n",
     "import arviz as az\n",
     "import pymc as pm\n",
+    "import pandas as pd\n",
+    "import bambi as bmb\n",
+    "\n",
     "from preliz.distributions import Normal, Gamma\n",
     "from preliz import predictive_explorer"
    ]
@@ -84,6 +87,48 @@
     "def test_predictive_explorer(model, iterations, kind_plot):\n",
     "    predictive_explorer(model, iterations, kind_plot, engine=\"pymc\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ffa022a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%ipytest\n",
+    "\n",
+    "data = pd.DataFrame(\n",
+    "    {\n",
+    "        \"y\": np.random.normal(size=117),\n",
+    "        \"x\": np.random.normal(size=117),\n",
+    "    }\n",
+    ")\n",
+    "data.head()\n",
+    "\n",
+    "@pytest.fixture\n",
+    "def model():\n",
+    "    def a_bambi_model(a_mu, b_sigma=1):\n",
+    "        prior = {\"Intercept\": bmb.Prior(\"Normal\", mu=a_mu, sigma=b_sigma)}\n",
+    "        a_model = bmb.Model(\"y ~ x\", data, priors=prior)\n",
+    "        return a_model\n",
+    "    return a_bambi_model\n",
+    "    \n",
+    "@pytest.mark.parametrize(\"iterations, kind_plot\", [\n",
+    "    (50, \"hist\"),\n",
+    "    (10, \"kde\"),\n",
+    "    (10, \"ecdf\"),\n",
+    "])\n",
+    "def test_predictive_explorer(model, iterations, kind_plot):\n",
+    "    predictive_explorer(model, iterations, kind_plot)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "675608f1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ nbformat==5.1.3
 lxml==5.0.0
 ipykernel
 pymc>=5.15.0
+bambi>=0.13.0


### PR DESCRIPTION
Closes #453 
Closes #451 
## Description
- Add support when `engine="auto"`
- Add support for Bambi Models.(Still need to write a case when the Priors are not provided by the user)
- Add docs and test.
- I changed `extract(idata, group="prior_predictive")[model.response_name].values` to `extract(idata, group="prior_predictive")[model.response_name].values.T`. This I think I missed in pymc but I have corrected it in this PR.
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add Poisson distribution".
  Avoid non-descriptive titles such as "Addresses issue #42".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request a broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Code style is correct (follows pylint and black guidelines)
- [x] Includes new or updated tests to cover the new feature
- [x] New features are properly documented (with an example if appropriate)
- [x] Includes a sample plot to visually illustrate the changes (only for plot-related functions)
- [x] Widget states have been properly saved (only for notebooks with widgets) [see](https://github.com/arviz-devs/preliz/wiki/Save-widgets-state) for details.

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/preliz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/preliz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
