### PR TITLE
don't run tests if only docs folder changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/"
   pull_request:
+    paths-ignore:
+      - "docs/"
 
 jobs:
   test:


### PR DESCRIPTION
I think this will prevent tests being executed when there are only changes in `docs/`
