### PR TITLE
Handle distributions which have r_v.owner.op.name = None

### DIFF
--- a/preliz/ppls/pymc_io.py
+++ b/preliz/ppls/pymc_io.py
@@ -123,8 +123,9 @@ def get_model_information(model):  # pylint: disable=too-many-locals
         size = r_v_eval.size
         shape = r_v_eval.shape
         nc_parents = non_constant_parents(r_v, model.free_RVs)
-
-        name = r_v.owner.op.name
+        name = (
+            r_v.owner.op.name if r_v.owner.op.name else str(r_v.owner.op).split("RV", 1)[0].lower()
+        )
         dist = pymc_to_preliz[name]
         p_model[r_v.name] = dist
         if nc_parents:


### PR DESCRIPTION
## Description
Some distributions such as `HalfStudentT` does not return r_v.owner.op.name(None), handling them should be easy and the below change should work.
<!--
Thank you so much for your PR! To help us review your contribution, please consider the following points:

- The PR title should summarize the changes, for example "Add Poisson distribution".
  Avoid non-descriptive titles such as "Addresses issue #42".

- The description should provide at least 1-2 sentences describing the pull request in detail and
  link to any relevant issues.

- Please prefix the title of incomplete contributions with [WIP] (to indicate a work in
  progress). WIPs may be useful to (1) indicate you are working on something to avoid
  duplicated work, (2) request a broad review of functionality or API, or (3) seek collaborators. -->

## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [x] Code style is correct (follows pylint and black guidelines)
- [x] Bug Fix

<!--
Also, please consider reading the contributing guidelines and code of conduct carefully before submitting the PR. They are available at
- https://github.com/arviz-devs/preliz/blob/main/CONTRIBUTING.md
- https://github.com/arviz-devs/preliz/blob/main/CODE_OF_CONDUCT.md

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in. Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
