### PR TITLE
Add Mode to Rice

### DIFF
--- a/preliz/distributions/rice.py
+++ b/preliz/distributions/rice.py
@@ -3,7 +3,7 @@ from scipy.special import chndtr, chndtrix, i0, i0e, i1
 
 from preliz.distributions.distributions import Continuous
 from preliz.internal.distribution_helper import all_not_none, eps
-from preliz.internal.optimization import optimize_ml, optimize_moments_rice
+from preliz.internal.optimization import find_mode, optimize_ml, optimize_moments_rice
 from preliz.internal.special import cdf_bounds, ppf_bounds_cont
 
 
@@ -128,6 +128,9 @@ class Rice(Continuous):
 
     def mean(self):
         return self.sigma * np.sqrt(np.pi / 2) * _l_half(-(self.nu**2) / (2 * self.sigma**2))
+
+    def mode(self):
+        return find_mode(self)
 
     def median(self):
         return self.ppf(0.5)


### PR DESCRIPTION
## Description

Since Rice's distribution has no closed-form mode, I used `find_mode`.

## Checklist

- [X] Code style is correct (follows ruff and black guidelines)