### PR TITLE
Add mode method for Discrete distributions

### DIFF
--- a/preliz/distributions/zi_binomial.py
+++ b/preliz/distributions/zi_binomial.py
@@ -2,11 +2,11 @@ import numba as nb
 import numpy as np
 from scipy.special import bdtr, bdtrik
 
+from preliz.distributions.binomial import Binomial
 from preliz.distributions.distributions import Discrete
 from preliz.internal.distribution_helper import all_not_none, eps
 from preliz.internal.optimization import optimize_ml, optimize_moments
 from preliz.internal.special import cdf_bounds, gammaln, ppf_bounds_disc
-from preliz.distributions.binomial import Binomial
 
 
 class ZeroInflatedBinomial(Discrete):

--- a/preliz/distributions/zi_binomial.py
+++ b/preliz/distributions/zi_binomial.py
@@ -2,10 +2,9 @@ import numba as nb
 import numpy as np
 from scipy.special import bdtr, bdtrik
 
-from preliz.distributions.binomial import Binomial
 from preliz.distributions.distributions import Discrete
 from preliz.internal.distribution_helper import all_not_none, eps
-from preliz.internal.optimization import optimize_ml, optimize_moments
+from preliz.internal.optimization import find_discrete_mode, optimize_ml, optimize_moments
 from preliz.internal.special import cdf_bounds, gammaln, ppf_bounds_disc
 
 
@@ -103,26 +102,7 @@ class ZeroInflatedBinomial(Discrete):
         return self.psi * self.n * self.p
 
     def mode(self):
-        binomial_raw_mode = Binomial(self.n, self.p).mode()
-        binomial_mode = (
-            min(binomial_raw_mode)
-            if isinstance(binomial_raw_mode, tuple)
-            else int(binomial_raw_mode)
-        )
-        if self.psi == 0:
-            return 0
-        elif self.psi == 1:
-            return binomial_mode
-        else:
-            prob_zero = (1 - self.psi) + self.psi * (1 - self.p) ** self.n
-            prob_binomial_mode = self.psi * np.exp(
-                gammaln(self.n + 1)
-                - gammaln(binomial_mode + 1)
-                - gammaln(self.n - binomial_mode + 1)
-                + binomial_mode * np.log(self.p)
-                + (self.n - binomial_mode) * np.log1p(-self.p)
-            )
-            return 0 if prob_zero > prob_binomial_mode else binomial_mode
+        return find_discrete_mode(self)
 
     def median(self):
         return self.ppf(0.5)

--- a/preliz/distributions/zi_negativebinomial.py
+++ b/preliz/distributions/zi_negativebinomial.py
@@ -4,7 +4,7 @@ from scipy.special import nbdtrik
 
 from preliz.distributions.distributions import Discrete
 from preliz.internal.distribution_helper import all_not_none, any_not_none, eps
-from preliz.internal.optimization import optimize_ml, optimize_moments
+from preliz.internal.optimization import find_discrete_mode, optimize_ml, optimize_moments
 from preliz.internal.special import betainc, cdf_bounds, gammaln, ppf_bounds_disc, xlogy
 
 
@@ -150,6 +150,9 @@ class ZeroInflatedNegativeBinomial(Discrete):
 
     def mean(self):
         return self.psi * self.mu
+
+    def mode(self):
+        return find_discrete_mode(self)
 
     def median(self):
         # missing explicit expression

--- a/preliz/distributions/zi_poisson.py
+++ b/preliz/distributions/zi_poisson.py
@@ -4,7 +4,7 @@ from scipy.special import pdtr, pdtrik
 
 from preliz.distributions.distributions import Discrete
 from preliz.internal.distribution_helper import all_not_none, eps
-from preliz.internal.optimization import optimize_ml, optimize_moments
+from preliz.internal.optimization import find_discrete_mode, optimize_ml, optimize_moments
 from preliz.internal.special import cdf_bounds, gammaln, ppf_bounds_disc, xlogy
 
 
@@ -112,6 +112,9 @@ class ZeroInflatedPoisson(Discrete):
 
     def mean(self):
         return self.psi * self.mu
+
+    def mode(self):
+        return find_discrete_mode(self)
 
     def median(self):
         return self.ppf(0.5)

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -515,6 +515,25 @@ def find_mode(distribution, bounds=None):
     return result.x
 
 
+def find_discrete_mode(dist):
+    """
+    Find mode for a discrete distribution via brute-force search.
+
+    Parameters
+    ----------
+    dist : Distribution
+        Discrete distribution object with pdf and xvals method.
+
+    Returns
+    -------
+    int
+        Mode of the distribution
+    """
+    x_vals = dist.xvals("full")
+    pmf_vals = dist.pdf(x_vals)
+    return int(x_vals[np.argmax(pmf_vals)])
+
+
 def find_ppf(dist, q):
     q = np.atleast_1d(q)
     ppf = np.zeros_like(q)

--- a/preliz/internal/optimization.py
+++ b/preliz/internal/optimization.py
@@ -517,12 +517,12 @@ def find_mode(distribution, bounds=None):
 
 def find_discrete_mode(dist):
     """
-    Find mode for a discrete distribution via brute-force search.
+    Find mode for a discrete distribution from its pmf.
 
     Parameters
     ----------
     dist : Distribution
-        Discrete distribution object with pdf and xvals method.
+        PreliZ distribution object
 
     Returns
     -------


### PR DESCRIPTION
## Description

- This PR adds `find_discrete_mode` in `internal.optimization`. It can be used in the remaining discrete distributions which don't have an analytical or simple solution for the mode. It evaluates the PMF over the distribution's support and returns the value with the highest probability.
- Applied this helper to the mode() method of ZeroInflatedBinomial, ZeroInflatedNegativeBinomial and ZeroInflatedPoisson.


## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [X] Code style is correct (follows ruff and black guidelines)