### PR TITLE
Add mode method to MvNormal

### DIFF
--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -423,6 +423,9 @@ class MvNormal(Continuous):
     def _fit_mle(self, sample, **kwargs):
         raise NotImplementedError
 
+    def mode(self):
+        return tuple(self.mu)
+
     def plot_pdf(
         self,
         marginals=True,

--- a/preliz/distributions/continuous_multivariate.py
+++ b/preliz/distributions/continuous_multivariate.py
@@ -424,7 +424,7 @@ class MvNormal(Continuous):
         raise NotImplementedError
 
     def mode(self):
-        return tuple(self.mu)
+        return self.mu
 
     def plot_pdf(
         self,


### PR DESCRIPTION
## Description

* The mode is simply defined as mu (https://en.wikipedia.org/wiki/Multivariate_normal_distribution).
* Returns a tuple with the mode values.

## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [X] Code style is correct (follows ruff and black guidelines)