### PR TITLE
Add Mode to Hurdle and Censored

### DIFF
--- a/preliz/distributions/censored.py
+++ b/preliz/distributions/censored.py
@@ -93,6 +93,16 @@ class Censored(DistributionTransformer):
         mean_trunc = Truncated(self.dist, self.lower, self.upper).mean()
         return xprody(self.lower, p_low) + mean_trunc * p_int + xprody(self.upper, p_up)
 
+    def mode(self):
+        if self.kind == "discrete":
+            from preliz.internal.optimization import find_discrete_mode
+
+            return find_discrete_mode(self)
+        else:
+            from preliz.internal.optimization import find_mode
+
+            return find_mode(self)
+
     def median(self):
         return np.clip(self.dist.median(), self.lower, self.upper)
 

--- a/preliz/distributions/hurdle.py
+++ b/preliz/distributions/hurdle.py
@@ -82,6 +82,16 @@ class Hurdle(DistributionTransformer):
         else:
             return np.trapz(x_values * pdf, x_values)
 
+    def mode(self):
+        if self.kind == "discrete":
+            from preliz.internal.optimization import find_discrete_mode
+
+            return find_discrete_mode(self)
+        else:
+            from preliz.internal.optimization import find_mode
+
+            return find_mode(self)
+
     def median(self):
         return self.ppf(0.5)
 


### PR DESCRIPTION
## Description

- Adds mode method to `Hurdle` and `Censored` distribution modifiers, using `find_mode` or `find_discrete_mode` depending on the base distribution type (the same we did with `Truncated`)
- Closes #604 

## Checklist
<!-- Feel free to remove check-list items that aren't relevant to your change -->

- [X] Code style is correct (follows ruff and black guidelines)