### PR TITLE
Make predictive explorer more flexible (in particular for PyMC and Bambi)

### DIFF
--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -145,6 +145,7 @@ init_vals = {
     "ZeroInflatedPoisson": {"psi": 0.8, "mu": 4.5},
     "Truncated": {"lower": -10, "upper": 10},
     "Censored": {"lower": -10, "upper": 10},
+    "Dirichlet": {"alpha": [1.0, 1.0, 1.0]},
 }
 
 

--- a/preliz/predictive/predictive_explorer.py
+++ b/preliz/predictive/predictive_explorer.py
@@ -12,13 +12,23 @@ from preliz.ppls.agnostic import (
 
 
 def predictive_explorer(
-    fmodel, samples=50, kind_plot="ecdf", references=None, plot_func=None, engine="auto"
+    fmodel,
+    samples=50,
+    kind_plot="ecdf",
+    references=None,
+    plot_func=None,
+    engine="auto",
+    group="prior_predictive",
+    var_name=None,
+    stats_kwargs=None,
 ):
     """
     Explore how changing parameters in the prior affects the prior predictive distribution.
 
-    Use this function to interactively explore how a prior predictive distribution changes when the
-    priors are changed.
+    Use this function to interactively explore how a prior predictive distribution changes
+    when the priors are changed. It also allows you to visualize how one prior changes when
+    another prior is changed, this can be useful for prior that are not set independently, but
+    are dependent on each other.
 
     Parameters
     ----------
@@ -40,13 +50,28 @@ def predictive_explorer(
         Library used to define the fmodel. Either `preliz`, `pymc` or `bambi`. Default is `auto`.
         The function will automatically select the appropriate library to use based on the fmodel
         provided.
+    group : str, optional
+        Which group to use. Ignored if the model is defined in `preliz`.
+        Defaults to "prior_predictive". You can also pass "prior".
+    var_name: str, optional
+        The name of the variable to plot. Ignored if the model is defined in `preliz`.
+        If "group=prior_predictive" it defaults to the first variable in `observed_RVs`.
+        For "prior" it defaults to the last variable in `free_RVs`.
+    stats_kwargs : dict, optional
+        Additional keyword arguments to pass to the statistics function.
+        Defaults to an empty dictionary.
     """
+    if stats_kwargs is None:
+        stats_kwargs = {}
     source, signature, engine = inspect_source(fmodel)
     model = parse_function_for_pred_textboxes(source, signature, engine)
-    textboxes = get_textboxes(signature, model)
-    new_fmodel = ppl_plot_decorator(fmodel, samples, kind_plot, references, plot_func, engine)
+    textboxes = get_textboxes(signature, model, kind_plot)
+    new_fmodel = ppl_plot_decorator(
+        fmodel, samples, kind_plot, references, plot_func, engine, group, var_name, stats_kwargs
+    )
     out = interactive_output(new_fmodel, textboxes)
     default_names = [
+        "__kind__",
         "__set_xlim__",
         "__x_min__",
         "__x_max__",


### PR DESCRIPTION
* Add `group` and `var_name` arguments. This mostly impacts interoperability with PyMC and Bambi. For example it allows to visualize prior variables or to select one observed variables when more than one in a model. This was possible for models specified using preliz, but not PyMC and Bambi.
* Add `stats_kwargs` argument to customize histogram, kde and ecdf.
* Add "kind" RadioButtons to the interface