### PR TITLE
Fix `Categorical.rvs` to sample categories using probabilities

### DIFF
--- a/preliz/distributions/categorical.py
+++ b/preliz/distributions/categorical.py
@@ -127,7 +127,7 @@ class Categorical(Discrete):
 
     def rvs(self, size=None, random_state=None):
         random_state = np.random.default_rng(random_state)
-        return random_state.choice(self.p, size)
+        return random_state.choice(len(self.p), size, p=self.p)
 
     def _fit_mle(self, sample):
         optimize_ml(self, sample)

--- a/preliz/distributions/categorical.py
+++ b/preliz/distributions/categorical.py
@@ -127,7 +127,8 @@ class Categorical(Discrete):
 
     def rvs(self, size=None, random_state=None):
         random_state = np.random.default_rng(random_state)
-        return random_state.choice(len(self.p), size, p=self.p)
+        support_array = np.arange(self.support[0], self.support[1] + 1)
+        return random_state.choice(support_array, size, p=self.p)
 
     def _fit_mle(self, sample):
         optimize_ml(self, sample)


### PR DESCRIPTION
## Description
This PR fixes the implementation of the `rvs` method in the Categorical distribution. Previously, `rvs` incorrectly sampled directly from the probability vector `p`, returning probability values instead of the category indices `{0, …, len(p)-1}`.

The corrected implementation uses `numpy.random.Generator.choice` to sample indices according to the weights `p`. 

This resolves issue #683 and ensures that random variates are consistent with the specified categorical distribution.

## Checklist
- [x] Code style is correct (follows ruff and black guidelines)