### PR TITLE
Remove deprecated pytensor.tensor arguments

### DIFF
--- a/preliz/internal/distribution_helper.py
+++ b/preliz/internal/distribution_helper.py
@@ -125,7 +125,8 @@ def pytensor_jit(func, **compile_kwargs):
         except KeyError:
             pass
         symbolic_args = [
-            tensor(broadcastable=bcast_pattern, dtype=dtype) for (bcast_pattern, dtype) in signature
+            tensor(shape=tuple(1 if b else None for b in bcast_pattern), dtype=dtype)
+            for (bcast_pattern, dtype) in signature
         ]
         symbolic_out = func(*symbolic_args)
         signature_to_function[signature] = compiled_func = function(
@@ -169,7 +170,7 @@ def pytensor_rng_jit(_func=None, **compile_kwargs):
                 pass
 
             symbolic_args = [
-                tensor(broadcastable=bcast_pattern, dtype=dtype)
+                tensor(shape=tuple(1 if b else None for b in bcast_pattern), dtype=dtype)
                 for (bcast_pattern, dtype) in signature[:-1]
             ]
             symbolic_size = (


### PR DESCRIPTION
Preliz emits warnings on the latest version of pytensor because it is using the deprecated `broadcastable` keyword argument of `pytensor.tensor.tensor`. This PR maintains the current behavior via the `shape` argument instead.