### PR TITLE
Fix import failure on matplotlib 3.11

### DIFF
--- a/preliz/__init__.py
+++ b/preliz/__init__.py
@@ -29,8 +29,11 @@ mpl_rcParams["savefig.bbox"] = "tight"
 
 # add PreliZ's styles to matplotlib's styles
 _preliz_style_path = os_path.join(os_path.dirname(__file__), "styles")
-style.core.USER_LIBRARY_PATHS.append(_preliz_style_path)
-style.core.reload_library()
+if hasattr(style, "USER_LIBRARY_PATHS"):
+    style.USER_LIBRARY_PATHS.append(_preliz_style_path)
+else:
+    style.core.USER_LIBRARY_PATHS.append(_preliz_style_path)
+style.reload_library()
 
 # clean namespace
 del os_path, mpl_rcParams, _preliz_style_path


### PR DESCRIPTION
## Description

matplotlib 3.11 no longer auto-imports the `matplotlib.style.core` submodule, so the `style.core.USER_LIBRARY_PATHS.append(...)` call in `preliz/__init__.py` raises `AttributeError` at import time. This uses the top-level `style.USER_LIBRARY_PATHS` when it exists, falls back to `style.core` for older matplotlib, and calls `style.reload_library()` (present on all supported versions).

Checked across matplotlib 3.9, 3.10, and 3.11: `style.USER_LIBRARY_PATHS` exists only on 3.11, `style.core` exists on 3.9 and 3.10, and `style.reload_library` exists on all three, so the guard covers the full `matplotlib>=3.9` range.

Closes #726.

## Checklist

- [x] Code style is correct (follows ruff guidelines)
